### PR TITLE
Initial pass at making slash commands respond as expected

### DIFF
--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionData.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionData.cs
@@ -1,9 +1,5 @@
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {
@@ -16,6 +12,6 @@ namespace Discord.API
         public string Name { get; set; }
 
         [JsonProperty("options")]
-        public Optional<ApplicationCommandInteractionDataOption[]> Options { get; set; } 
+        public List<ApplicationCommandInteractionDataOption> Options { get; set; } = new();
     }
 }

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionDataOption.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionDataOption.cs
@@ -1,9 +1,5 @@
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {
@@ -16,6 +12,6 @@ namespace Discord.API
         public Optional<object> Value { get; set; }
 
         [JsonProperty("options")]
-        public Optional<IEnumerable<ApplicationCommandInteractionDataOption>> Options { get; set; }
+        public List<ApplicationCommandInteractionDataOption> Options { get; set; } = new();
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommand.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommand.cs
@@ -1,12 +1,9 @@
 using Discord.Rest;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Model = Discord.API.Gateway.InteractionCreated;
 using DataModel = Discord.API.ApplicationCommandInteractionData;
+using Model = Discord.API.Gateway.InteractionCreated;
 
 namespace Discord.WebSocket
 {
@@ -40,7 +37,7 @@ namespace Discord.WebSocket
                 (model.Data.Value as JToken).ToObject<DataModel>()
                 : null;
 
-            this.Data.Update(data, this.Guild.Id);
+            this.Data.Update(data, model.GuildId);
 
             base.Update(model);
         }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommand.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommand.cs
@@ -1,6 +1,7 @@
 using Discord.Rest;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using DataModel = Discord.API.ApplicationCommandInteractionData;
 using Model = Discord.API.Gateway.InteractionCreated;

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommandData.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommandData.cs
@@ -1,9 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Model = Discord.API.ApplicationCommandInteractionData;
 
 namespace Discord.WebSocket
@@ -14,7 +11,7 @@ namespace Discord.WebSocket
         public string Name { get; private set; }
 
         /// <summary>
-        ///     The <see cref="SocketSlashCommandDataOption"/>'s recieved with this interaction.
+        ///     The <see cref="SocketSlashCommandDataOption"/>'s received with this interaction.
         /// </summary>
         public IReadOnlyCollection<SocketSlashCommandDataOption> Options { get; private set; }
 
@@ -37,8 +34,8 @@ namespace Discord.WebSocket
             this.Name = model.Name;
             this.guildId = guildId;
 
-            this.Options = model.Options.IsSpecified
-                ? model.Options.Value.Select(x => new SocketSlashCommandDataOption(x, this.Discord, guildId)).ToImmutableArray()
+            this.Options = model.Options.Any()
+                ? model.Options.Select(x => new SocketSlashCommandDataOption(x, this.Discord, guildId)).ToImmutableArray()
                 : null;
         }
 

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommandDataOption.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommandDataOption.cs
@@ -1,9 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Model = Discord.API.ApplicationCommandInteractionDataOption;
 
 namespace Discord.WebSocket
@@ -20,7 +17,7 @@ namespace Discord.WebSocket
         public object Value { get; private set; }
 
         /// <summary>
-        ///      The sub command options recieved for this sub command group.
+        ///      The sub command options received for this sub command group.
         /// </summary>
         public IReadOnlyCollection<SocketSlashCommandDataOption> Options { get; private set; }
 
@@ -35,8 +32,8 @@ namespace Discord.WebSocket
             this.discord = discord;
             this.guild = guild;
 
-            this.Options = model.Options.IsSpecified
-                ? model.Options.Value.Select(x => new SocketSlashCommandDataOption(x, discord, guild)).ToImmutableArray()
+            this.Options = model.Options.Any()
+                ? model.Options.Select(x => new SocketSlashCommandDataOption(x, discord, guild)).ToImmutableArray()
                 : null;
         }
 


### PR DESCRIPTION
In trying to make slash commands functional for my own bot, I wanted to surface these potential fixes that I implemented to make commands respond as expected.

A couple of these modifications ignored a pattern established with the usage of the Optional<T> struct.

`src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionData.cs` 
`src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionDataOption.cs`

These 2 files, I was unfamiliar with the implementation of the Optional struct - but I am familiar with de-serializing JSON objects .. and if a list of objects is empty, it can be treated as optional. Modified our Optional Array struct to Lists of objects, which default to empty.

`src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommand.cs`

this.Guild.Id was null. model.GuildId was not. Passing this through, clears this issue.

`src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommandData.cs`
`src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommandDataOption.cs`

With the removal of the Optional struct, we no longer had IsSpecified, so a .Any resolves that.

--

These are just proposals - I think if the pattern is to stick with Optional<T>, it needs to have logic added to it to handle empty JSON list data being fed into it. It seems to fall apart if it doesnt see what it's expecting.