### PR TITLE
Add IsSpecified check to Author field

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Interaction/Message Components/SocketMessageComponent.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Message Components/SocketMessageComponent.cs
@@ -50,15 +50,15 @@ namespace Discord.WebSocket
             {
                 if (this.Message == null)
                 {
-                    SocketUser author;
+                    SocketUser author = null;
                     if (this.Channel is SocketGuildChannel channel)
                     {
                         if (model.Message.Value.WebhookId.IsSpecified)
                             author = SocketWebhookUser.Create(channel.Guild, Discord.State, model.Message.Value.Author.Value, model.Message.Value.WebhookId.Value);
-                        else
+                        else if (model.Message.Value.Author.IsSpecified)
                             author = channel.Guild.GetUser(model.Message.Value.Author.Value.Id);
                     }
-                    else
+                    else if (model.Message.Value.Author.IsSpecified)
                         author = (this.Channel as SocketChannel).GetUser(model.Message.Value.Author.Value.Id);
 
                     this.Message = SocketUserMessage.Create(this.Discord, this.Discord.State, author, this.Channel, model.Message.Value);


### PR DESCRIPTION
From break pointing it seems like ephemeral (specific?) messages don't always send along an author property.

This, from testing of the code, directly relate to my issue talked about in #bugs as I haven't had any issues with it since.

If this isn't valid and you always want to ensure that an Author is sent along with the SocketMessageComponent, feel free to close this PR.