### PR TITLE
Fix Emoji UnicodeAndNames throwing exception because of duplicit keys

### DIFF
--- a/src/Discord.Net.Core/Entities/Emotes/Emoji.cs
+++ b/src/Discord.Net.Core/Entities/Emotes/Emoji.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 
 namespace Discord
@@ -5942,12 +5943,21 @@ namespace Discord
       ["♡"] = "❤️"
         };
 
-        private static IReadOnlyDictionary<string, string> _unicodesAndNames;
-        private static IReadOnlyDictionary<string, string> UnicodesAndNames
+        private static IReadOnlyDictionary<string, ReadOnlyCollection<string>> _unicodesAndNames;
+        private static IReadOnlyDictionary<string, ReadOnlyCollection<string>> UnicodesAndNames
         {
             get
             {
-                _unicodesAndNames ??= NamesAndUnicodes.ToDictionary(kvp => kvp.Value, kvp => kvp.Key);
+                _unicodesAndNames ??= new System.Collections.ObjectModel.ReadOnlyDictionary<string, ReadOnlyCollection<string>>(
+                    NamesAndUnicodes
+                        .GroupBy(kvp => kvp.Value)
+                        .ToDictionary(
+                            grouping => grouping.Key,
+                            grouping => grouping.Select(kvp => kvp.Key)
+                                .ToList()
+                                .AsReadOnly()
+                            )
+                    );
                 return _unicodesAndNames;
             }
         }

--- a/src/Discord.Net.Core/Entities/Emotes/Emoji.cs
+++ b/src/Discord.Net.Core/Entities/Emotes/Emoji.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Linq;
 
@@ -57,7 +58,7 @@ namespace Discord
             if (NamesAndUnicodes.ContainsKey(text))
                 result = new Emoji(NamesAndUnicodes[text]);
 
-            if (UnicodesAndNames.ContainsKey(text))
+            if (Unicodes.Contains(text))
                 result = new Emoji(text);
 
             return result != null;
@@ -5943,6 +5944,15 @@ namespace Discord
       ["♡"] = "❤️"
         };
 
+        private static IReadOnlyCollection<string> _unicodes;
+        private static IReadOnlyCollection<string> Unicodes
+        {
+            get
+            {
+                _unicodes ??= NamesAndUnicodes.Select(kvp => kvp.Value).ToImmutableHashSet();
+                return _unicodes;
+            }
+        }
 
         private static IReadOnlyDictionary<string, ReadOnlyCollection<string>> _unicodesAndNames;
         private static IReadOnlyDictionary<string, ReadOnlyCollection<string>> UnicodesAndNames

--- a/src/Discord.Net.Core/Entities/Emotes/Emoji.cs
+++ b/src/Discord.Net.Core/Entities/Emotes/Emoji.cs
@@ -5943,21 +5943,21 @@ namespace Discord
       ["♡"] = "❤️"
         };
 
+
         private static IReadOnlyDictionary<string, ReadOnlyCollection<string>> _unicodesAndNames;
         private static IReadOnlyDictionary<string, ReadOnlyCollection<string>> UnicodesAndNames
         {
             get
             {
-                _unicodesAndNames ??= new System.Collections.ObjectModel.ReadOnlyDictionary<string, ReadOnlyCollection<string>>(
+                _unicodesAndNames ??=
                     NamesAndUnicodes
                         .GroupBy(kvp => kvp.Value)
-                        .ToDictionary(
+                        .ToImmutableDictionary(
                             grouping => grouping.Key,
                             grouping => grouping.Select(kvp => kvp.Key)
                                 .ToList()
                                 .AsReadOnly()
-                            )
-                    );
+                        );
                 return _unicodesAndNames;
             }
         }


### PR DESCRIPTION
Simple convert of key to value and vice versa when obtaining UnicodeAndNames from NamesAndUnicodes is not possible as there are multiple values to send the same emoji (:-), :), :slight_smile: etc.)

I've came up with a solution where the dictionary contains readonly collection of the possible names. Using LINQ the collection is grouped, then converted to dictionary.