### PR TITLE
Fix SocketSlashCommandDataOption to use long for Number instead of int

### DIFF
--- a/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommandDataOption.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommandDataOption.cs
@@ -86,9 +86,9 @@ namespace Discord.WebSocket
                         break;
                     case ApplicationCommandOptionType.Integer:
                         {
-                            if (model.Value.Value is int val)
+                            if (model.Value.Value is long val)
                                 this.Value = val;
-                            else if (int.TryParse(model.Value.Value.ToString(), out int res))
+                            else if (long.TryParse(model.Value.Value.ToString(), out long res))
                                 this.Value = res;
                         }
                         break;
@@ -109,7 +109,7 @@ namespace Discord.WebSocket
                         }
                         break;
                 }
-                
+
             }
 
             this.Options = model.Options.IsSpecified


### PR DESCRIPTION
Discord documentation of slash commands says that for option of type INTEGER: `Any integer between -2^53 and 2^53`.
The problem is that current implementation of Discord.NET Labs converts the value to `int32` and thus it cannot do so for values larger than `2^31-1`. I don't think that's the expected behavior, so I made PR right away.
I changed the type to `int64` - `long` as that is the closest to the value allowed by discord.

Note on current behavior: if value out of `int32` range was specified, `null` was assigned to the `Value`.

I targeted `release/3.x`, not sure if that is the correct branch to target now. If not, let me know and I will change it/make a new PR.