### PR TITLE
Fix MessageProperties.Embed being ignored in some methods

### DIFF
--- a/src/Discord.Net.Core/Discord.Net.Core.xml
+++ b/src/Discord.Net.Core/Discord.Net.Core.xml
@@ -7602,7 +7602,7 @@
                 Gets or sets a single embed for this message.
             </summary>
             <remarks>
-                This property will be added to the <see cref="P:Discord.MessageProperties.Embed"/> array, in the future please use the array rather then this property.
+                This property will be added to the <see cref="P:Discord.MessageProperties.Embeds"/> array, in the future please use the array rather than this property.
             </remarks>
         </member>
         <member name="P:Discord.MessageProperties.Embeds">

--- a/src/Discord.Net.Core/Entities/Messages/MessageProperties.cs
+++ b/src/Discord.Net.Core/Entities/Messages/MessageProperties.cs
@@ -22,7 +22,7 @@ namespace Discord
         ///     Gets or sets a single embed for this message.
         /// </summary>
         /// <remarks>
-        ///     This property will be added to the <see cref="Embed"/> array, in the future please use the array rather then this property.
+        ///     This property will be added to the <see cref="Embeds"/> array, in the future please use the array rather than this property.
         /// </remarks>
         public Optional<Embed> Embed { get; set; }
 

--- a/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
@@ -1,3 +1,4 @@
+using Discord.API;
 using Discord.API.Rest;
 using System;
 using System.Collections.Generic;
@@ -33,9 +34,13 @@ namespace Discord.Rest
             if (msg.Author.Id != client.CurrentUser.Id && (args.Content.IsSpecified || args.Embeds.IsSpecified || args.AllowedMentions.IsSpecified))
                 throw new InvalidOperationException("Only the author of a message may modify the message content, embed, or allowed mentions.");
 
+            var embed = args.Embed;
+            var embeds = args.Embeds;
+
             bool hasText = args.Content.IsSpecified ? !string.IsNullOrEmpty(args.Content.Value) : !string.IsNullOrEmpty(msg.Content);
-            bool hasEmbed = args.Embeds.IsSpecified ? args.Embeds.Value != null : msg.Embeds.Any();
-            if (!hasText && !hasEmbed)
+            bool hasEmbeds = (embed.IsSpecified && embed.Value != null) || (embeds.IsSpecified && embeds.Value?.Length > 0) || msg.Embeds.Any();
+
+            if (!hasText && !hasEmbeds)
                 Preconditions.NotNullOrEmpty(args.Content.IsSpecified ? args.Content.Value : string.Empty, nameof(args.Content));
 
             if (args.AllowedMentions.IsSpecified)
@@ -61,22 +66,24 @@ namespace Discord.Rest
                 }
             }
 
-            var embeds = new List<API.Embed>();
+            var apiEmbeds = embed.IsSpecified || embeds.IsSpecified ? new List<API.Embed>() : null;
 
-            if (args.Embed.IsSpecified)
+            if (embed.IsSpecified && embed.Value != null)
             {
-                embeds.Add(args.Embed.Value.ToModel());
+                apiEmbeds.Add(embed.Value.ToModel());
             }
 
-            if (args.Embeds.IsSpecified)
+            if (embeds.IsSpecified && embeds.Value != null)
             {
-                embeds.AddRange(args.Embeds.Value.Select(x => x.ToModel()));
+                apiEmbeds.AddRange(embeds.Value.Select(x => x.ToModel()));
             }
+
+            Preconditions.AtMost(apiEmbeds?.Count ?? 0, 10, nameof(args.Embeds), "A max of 10 embeds are allowed.");
 
             var apiArgs = new ModifyMessageParams
             {
                 Content = args.Content,
-                Embeds = embeds.ToArray(),
+                Embeds = apiEmbeds?.ToArray() ?? Optional<API.Embed[]>.Unspecified,
                 Components = args.Components.IsSpecified ? args.Components.Value?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() : Optional<API.ActionRowComponent[]>.Unspecified,
                 Flags = args.Flags,
                 AllowedMentions = args.AllowedMentions.IsSpecified ? args.AllowedMentions.Value.ToModel() : Optional<API.AllowedMentions>.Unspecified,
@@ -90,7 +97,13 @@ namespace Discord.Rest
             var args = new MessageProperties();
             func(args);
 
-            if (args.Content.IsSpecified && string.IsNullOrEmpty(args.Content.Value) && args.Embeds.IsSpecified && args.Embeds.Value == null)
+            var embed = args.Embed;
+            var embeds = args.Embeds;
+
+            bool hasText = args.Content.IsSpecified && string.IsNullOrEmpty(args.Content.Value);
+            bool hasEmbeds = (embed.IsSpecified && embed.Value != null) || (embeds.IsSpecified && embeds.Value?.Length > 0);
+
+            if (!hasText && !hasEmbeds)
                 Preconditions.NotNullOrEmpty(args.Content.IsSpecified ? args.Content.Value : string.Empty, nameof(args.Content));
 
             if (args.AllowedMentions.IsSpecified)
@@ -117,22 +130,24 @@ namespace Discord.Rest
                 }
             }
 
-            var embeds = new List<API.Embed>();
+            var apiEmbeds = embed.IsSpecified || embeds.IsSpecified ? new List<API.Embed>() : null;
 
-            if (args.Embed.IsSpecified)
+            if (embed.IsSpecified && embed.Value != null)
             {
-                embeds.Add(args.Embed.Value.ToModel());
+                apiEmbeds.Add(embed.Value.ToModel());
             }
 
-            if (args.Embeds.IsSpecified)
+            if (embeds.IsSpecified && embeds.Value != null)
             {
-                embeds.AddRange(args.Embeds.Value.Select(x => x.ToModel()));
+                apiEmbeds.AddRange(embeds.Value.Select(x => x.ToModel()));
             }
+
+            Preconditions.AtMost(apiEmbeds?.Count ?? 0, 10, nameof(args.Embeds), "A max of 10 embeds are allowed.");
 
             var apiArgs = new API.Rest.ModifyMessageParams
             {
                 Content = args.Content,
-                Embeds = embeds.ToArray(),
+                Embeds = apiEmbeds?.ToArray() ?? Optional<API.Embed[]>.Unspecified,
                 Flags = args.Flags.IsSpecified ? args.Flags.Value : Optional.Create<MessageFlags?>(),
                 AllowedMentions = args.AllowedMentions.IsSpecified ? args.AllowedMentions.Value.ToModel() : Optional.Create<API.AllowedMentions>(),
                 Components = args.Components.IsSpecified ? args.Components.Value?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() : Optional<API.ActionRowComponent[]>.Unspecified,


### PR DESCRIPTION
This PR fixes `MessageProperties.Embed` being ignored when modifying a message and also fixes some bugs in the validation of `Embed` and `Embeds`.