### PR TITLE
Gateway serialization was recently changed to not send null values

### DIFF
--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -55,7 +55,7 @@ namespace Discord.API
             _restClientProvider = restClientProvider;
             UserAgent = userAgent;
             DefaultRetryMode = defaultRetryMode;
-            _serializer = serializer ?? new JsonSerializer { ContractResolver = new DiscordContractResolver(), NullValueHandling = NullValueHandling.Ignore };
+            _serializer = serializer ?? new JsonSerializer { ContractResolver = new DiscordContractResolver(), NullValueHandling = NullValueHandling.Include };
             UseSystemClock = useSystemClock;
 
             RequestQueue = new RequestQueue();


### PR DESCRIPTION
Possibly resolve #94

Hello, recently DiscordRestApiClient was changed so that it doesn't serialize null values to json.
@INikonI did that change, so he should be able to answer why.

I am not sure whether changing it to Include instead of Ignore breaks anything. The problem is that Ignore breaks joining channels as channelId is expected to be present, but null in case of disconnects.