### PR TITLE
Allow EmbedBuilder.ImageUrl to use attachment scheme syntax

### DIFF
--- a/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Messages/EmbedBuilder.cs
@@ -411,7 +411,7 @@ namespace Discord
                 UrlValidation.Validate(Url);
             if (!string.IsNullOrEmpty(ThumbnailUrl))
                 UrlValidation.Validate(ThumbnailUrl);
-            if (!string.IsNullOrEmpty(ImageUrl))
+            if (!string.IsNullOrEmpty(ImageUrl) && !ImageUrl.StartsWith("attachment://", StringComparison.Ordinal))
                 UrlValidation.Validate(ImageUrl);
             if (Author != null)
             {


### PR DESCRIPTION
Fixes the bug in EmbedBuilder that prevented the use of attachments inside embeds.