### PR TITLE
Make Webhook ApplicationId nullable instead of optional + fix IDiscordInteraction DeferAsync method

### DIFF
--- a/src/Discord.Net.Core/Discord.Net.Core.xml
+++ b/src/Discord.Net.Core/Discord.Net.Core.xml
@@ -4691,7 +4691,7 @@
             <param name="options">The request options for this async request.</param>
             <returns>A <see cref="T:Discord.IUserMessage"/> that represents the initial response.</returns>
         </member>
-        <member name="M:Discord.IDiscordInteraction.DeferAsync(Discord.RequestOptions)">
+        <member name="M:Discord.IDiscordInteraction.DeferAsync(System.Boolean,Discord.RequestOptions)">
             <summary>
                 Acknowledges this interaction.
             </summary>

--- a/src/Discord.Net.Core/Entities/Interactions/IDiscordInteraction.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IDiscordInteraction.cs
@@ -92,6 +92,6 @@ namespace Discord
         /// <returns>
         ///     A task that represents the asynchronous operation of acknowledging the interaction.
         /// </returns>
-        Task DeferAsync (RequestOptions options = null);
+        Task DeferAsync (bool ephemeral = false, RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Webhook.cs
+++ b/src/Discord.Net.Rest/API/Common/Webhook.cs
@@ -22,6 +22,6 @@ namespace Discord.API
         [JsonProperty("user")]
         public Optional<User> Creator { get; set; }
         [JsonProperty("application_id")]
-        public Optional<ulong> ApplicationId { get; set; }
+        public ulong? ApplicationId { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Webhooks/RestWebhook.cs
+++ b/src/Discord.Net.Rest/Entities/Webhooks/RestWebhook.cs
@@ -68,8 +68,8 @@ namespace Discord.Rest
                 GuildId = model.GuildId.Value;
             if (model.Name.IsSpecified)
                 Name = model.Name.Value;
-            if (model.ApplicationId.IsSpecified)
-                ApplicationId = model.ApplicationId.Value;
+
+            ApplicationId = model.ApplicationId;
         }
 
         /// <inheritdoc />

--- a/src/Discord.Net.Webhook/Entities/Webhooks/RestInternalWebhook.cs
+++ b/src/Discord.Net.Webhook/Entities/Webhooks/RestInternalWebhook.cs
@@ -45,8 +45,8 @@ namespace Discord.Webhook
                 GuildId = model.GuildId.Value;
             if (model.Name.IsSpecified)
                 Name = model.Name.Value;
-            if (model.ApplicationId.IsSpecified)
-                ApplicationId = model.ApplicationId.Value;
+
+            ApplicationId = model.ApplicationId;
         }
 
         public string GetAvatarUrl(ImageFormat format = ImageFormat.Auto, ushort size = 128)


### PR DESCRIPTION
Hello, there is a problem with `Webhook` type as in the code ApplicationId is of type `Optional<ulong>`. The problem is that according to the documentation https://discord.com/developers/docs/resources/webhook#webhook-resource, `application_id` is not optional, but may be null. This means that now if the application is null, this will throw an exception.

I've changed type `Optional<ulong>` to `ulong?`. This seems to be working okay for both with and without application. But I don't have read that much code for Optional and OptionalConverters etc., so I am not sure whether this is the best solution for this?

Second problem is that Discord.NET code could not be compiled as recently interface `IDiscordInteraction` was added, but it did not contain `bool ephemeral`, that was also added recently.