### PR TITLE
BannerId to nullable as stated in API

### DIFF
--- a/src/Discord.Net.Core/Entities/Users/IUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IUser.cs
@@ -12,11 +12,11 @@ namespace Discord
         /// </summary>
         string AvatarId { get; }
         /// <summary>
-        ///     Gets the identifier of this user's banner.
+        ///     Gets the identifier of this user's banner. <c>Null</c> if not available.
         /// </summary>
         string? BannerId { get; }
         /// <summary>
-        ///     Gets the user's banner color. <c>Null</c> if not set.
+        ///     Gets the user's banner color. <c>Null</c> if not available.
         /// </summary>
         /// <returns>
         ///     A <see cref="Color"/> struct representing the accent color of this user's banner.

--- a/src/Discord.Net.Core/Entities/Users/IUser.cs
+++ b/src/Discord.Net.Core/Entities/Users/IUser.cs
@@ -14,9 +14,9 @@ namespace Discord
         /// <summary>
         ///     Gets the identifier of this user's banner.
         /// </summary>
-        string BannerId { get; }
+        string? BannerId { get; }
         /// <summary>
-        ///     Gets the user's banner color.
+        ///     Gets the user's banner color. <c>Null</c> if not set.
         /// </summary>
         /// <returns>
         ///     A <see cref="Color"/> struct representing the accent color of this user's banner.

--- a/src/Discord.Net.Rest/Entities/Users/RestUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestUser.cs
@@ -22,7 +22,7 @@ namespace Discord.Rest
         /// <inheritdoc />
         public string AvatarId { get; private set; }
         /// <inheritdoc />
-        public string BannerId { get; private set; }
+        public string? BannerId { get; private set; }
         /// <inheritdoc />
         public Color? AccentColor { get; private set; }
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGlobalUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGlobalUser.cs
@@ -12,7 +12,7 @@ namespace Discord.WebSocket
         public override string Username { get; internal set; }
         public override ushort DiscriminatorValue { get; internal set; }
         public override string AvatarId { get; internal set; }
-        public override string BannerId { get; internal set; }
+        public override string? BannerId { get; internal set; }
         public override Color? AccentColor { get; internal set; }
         internal override SocketPresence Presence { get; set; }
 

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGroupUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGroupUser.cs
@@ -29,7 +29,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public override string AvatarId { get { return GlobalUser.AvatarId; } internal set { GlobalUser.AvatarId = value; } }
         /// <inheritdoc />
-        public override string BannerId { get { return GlobalUser.BannerId; } internal set { GlobalUser.BannerId = value; } }
+        public override string? BannerId { get { return GlobalUser.BannerId; } internal set { GlobalUser.BannerId = value; } }
         /// <inheritdoc />
         public override Color? AccentColor { get { return GlobalUser.AccentColor; } internal set { GlobalUser.AccentColor = value; } }
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketGuildUser.cs
@@ -39,7 +39,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public override string AvatarId { get { return GlobalUser.AvatarId; } internal set { GlobalUser.AvatarId = value; } }
         /// <inheritdoc />
-        public override string BannerId { get { return GlobalUser.BannerId; } internal set { GlobalUser.BannerId = value; } }
+        public override string? BannerId { get { return GlobalUser.BannerId; } internal set { GlobalUser.BannerId = value; } }
         /// <inheritdoc />
         public override Color? AccentColor { get { return GlobalUser.AccentColor; } internal set { GlobalUser.AccentColor = value; } }
 

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketSelfUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketSelfUser.cs
@@ -29,7 +29,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public override string AvatarId { get { return GlobalUser.AvatarId; } internal set { GlobalUser.AvatarId = value; } }
         /// <inheritdoc />
-        public override string BannerId { get { return GlobalUser.BannerId; } internal set { GlobalUser.BannerId = value; } }
+        public override string? BannerId { get { return GlobalUser.BannerId; } internal set { GlobalUser.BannerId = value; } }
         /// <inheritdoc />
         public override Color? AccentColor { get { return GlobalUser.AccentColor; } internal set { GlobalUser.AccentColor = value; } }
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketThreadUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketThreadUser.cs
@@ -54,7 +54,7 @@ namespace Discord.WebSocket
         }
 
         /// <inheritdoc/>
-        public override string BannerId
+        public override string? BannerId
         {
             get => GuildUser.BannerId;
             internal set => GuildUser.BannerId = value;

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUnknownUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUnknownUser.cs
@@ -21,7 +21,7 @@ namespace Discord.WebSocket
         public override string AvatarId { get; internal set; }
 
         /// <inheritdoc />
-        public override string BannerId { get; internal set; }
+        public override string? BannerId { get; internal set; }
 
         /// <inheritdoc />
         public override Color? AccentColor { get; internal set; }

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketUser.cs
@@ -25,7 +25,7 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public abstract string AvatarId { get; internal set; }
         /// <inheritdoc />
-        public abstract string BannerId { get; internal set; }
+        public abstract string? BannerId { get; internal set; }
         /// <inheritdoc />
         public abstract Color? AccentColor { get; internal set; }
         /// <inheritdoc />


### PR DESCRIPTION
Changed BannerId to nullable, as presented in API documentation. Needs review to resolve warning ` CS8632 ` (nullable notation). 

Note: First 2 commits were on gh, as I assumed it would be minor change. The others are authored in VS.

