### PR TITLE
Fix modifying application command by generic ModifyAsync

### DIFF
--- a/src/Discord.Net.Core/Discord.Net.Core.xml
+++ b/src/Discord.Net.Core/Discord.Net.Core.xml
@@ -4686,7 +4686,7 @@
         </member>
         <member name="T:Discord.IApplicationCommand">
             <summary>
-                The base command model that belongs to an application. 
+                The base command model that belongs to an application.
             </summary>
         </member>
         <member name="P:Discord.IApplicationCommand.ApplicationId">
@@ -4719,7 +4719,7 @@
                 If the option is a subcommand or subcommand group type, this nested options will be the parameters.
             </summary>
         </member>
-        <member name="M:Discord.IApplicationCommand.ModifyAsync(System.Action{Discord.ApplicationCommandProperties},Discord.RequestOptions)">
+        <member name="M:Discord.IApplicationCommand.ModifyAsync``1(System.Action{``0},Discord.RequestOptions)">
             <summary>
                 Modifies the current application command.
             </summary>

--- a/src/Discord.Net.Core/Discord.Net.Core.xml
+++ b/src/Discord.Net.Core/Discord.Net.Core.xml
@@ -4719,6 +4719,16 @@
                 If the option is a subcommand or subcommand group type, this nested options will be the parameters.
             </summary>
         </member>
+        <member name="M:Discord.IApplicationCommand.ModifyAsync(System.Action{Discord.ApplicationCommandProperties},Discord.RequestOptions)">
+            <summary>
+                Modifies the current application command.
+            </summary>
+            <param name="func">The new properties to use when modifying the command.</param>
+            <param name="options">The options to be used when sending the request.</param>
+            <returns>
+                A task that represents the asynchronous modification operation.
+            </returns>
+        </member>
         <member name="M:Discord.IApplicationCommand.ModifyAsync``1(System.Action{``0},Discord.RequestOptions)">
             <summary>
                 Modifies the current application command.
@@ -4728,6 +4738,7 @@
             <returns>
                 A task that represents the asynchronous modification operation.
             </returns>
+            <exception cref="T:System.InvalidOperationException">Thrown when you pass in an invalid <see cref="T:Discord.ApplicationCommandProperties"/> type.</exception>
         </member>
         <member name="T:Discord.IApplicationCommandInteractionData">
             <summary>

--- a/src/Discord.Net.Core/Entities/Interactions/IApplicationCommand.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IApplicationCommand.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Discord
 {
     /// <summary>
-    ///     The base command model that belongs to an application. 
+    ///     The base command model that belongs to an application.
     /// </summary>
     public interface IApplicationCommand : ISnowflakeEntity, IDeletable
     {
@@ -49,6 +49,7 @@ namespace Discord
         /// <returns>
         ///     A task that represents the asynchronous modification operation.
         /// </returns>
-        Task ModifyAsync(Action<ApplicationCommandProperties> func, RequestOptions options = null);
+        Task ModifyAsync<TArg>(Action<TArg> func, RequestOptions options = null)
+            where TArg : ApplicationCommandProperties;
     }
 }

--- a/src/Discord.Net.Core/Entities/Interactions/IApplicationCommand.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IApplicationCommand.cs
@@ -49,6 +49,17 @@ namespace Discord
         /// <returns>
         ///     A task that represents the asynchronous modification operation.
         /// </returns>
+        Task ModifyAsync(Action<ApplicationCommandProperties> func, RequestOptions options = null);
+
+        /// <summary>
+        ///     Modifies the current application command.
+        /// </summary>
+        /// <param name="func">The new properties to use when modifying the command.</param>
+        /// <param name="options">The options to be used when sending the request.</param>
+        /// <returns>
+        ///     A task that represents the asynchronous modification operation.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">Thrown when you pass in an invalid <see cref="ApplicationCommandProperties"/> type.</exception>
         Task ModifyAsync<TArg>(Action<TArg> func, RequestOptions options = null)
             where TArg : ApplicationCommandProperties;
     }

--- a/src/Discord.Net.Rest/Discord.Net.Rest.xml
+++ b/src/Discord.Net.Rest/Discord.Net.Rest.xml
@@ -3909,6 +3909,9 @@
         <member name="M:Discord.Rest.RestApplicationCommand.DeleteAsync(Discord.RequestOptions)">
             <inheritdoc/>
         </member>
+        <member name="M:Discord.Rest.RestApplicationCommand.ModifyAsync(System.Action{Discord.ApplicationCommandProperties},Discord.RequestOptions)">
+            <inheritdoc />
+        </member>
         <member name="M:Discord.Rest.RestApplicationCommand.ModifyAsync``1(System.Action{``0},Discord.RequestOptions)">
             <inheritdoc/>
         </member>

--- a/src/Discord.Net.Rest/Discord.Net.Rest.xml
+++ b/src/Discord.Net.Rest/Discord.Net.Rest.xml
@@ -3909,7 +3909,7 @@
         <member name="M:Discord.Rest.RestApplicationCommand.DeleteAsync(Discord.RequestOptions)">
             <inheritdoc/>
         </member>
-        <member name="M:Discord.Rest.RestApplicationCommand.ModifyAsync(System.Action{Discord.ApplicationCommandProperties},Discord.RequestOptions)">
+        <member name="M:Discord.Rest.RestApplicationCommand.ModifyAsync``1(System.Action{``0},Discord.RequestOptions)">
             <inheritdoc/>
         </member>
         <member name="T:Discord.Rest.RestApplicationCommandChoice">
@@ -3961,7 +3961,7 @@
         <member name="M:Discord.Rest.RestGlobalCommand.DeleteAsync(Discord.RequestOptions)">
             <inheritdoc/>
         </member>
-        <member name="M:Discord.Rest.RestGlobalCommand.ModifyAsync(System.Action{Discord.ApplicationCommandProperties},Discord.RequestOptions)">
+        <member name="M:Discord.Rest.RestGlobalCommand.ModifyAsync``1(System.Action{``0},Discord.RequestOptions)">
             <summary>
                 Modifies this <see cref="T:Discord.Rest.RestApplicationCommand"/>.
             </summary>
@@ -3984,7 +3984,7 @@
         <member name="M:Discord.Rest.RestGuildCommand.DeleteAsync(Discord.RequestOptions)">
             <inheritdoc/>
         </member>
-        <member name="M:Discord.Rest.RestGuildCommand.ModifyAsync(System.Action{Discord.ApplicationCommandProperties},Discord.RequestOptions)">
+        <member name="M:Discord.Rest.RestGuildCommand.ModifyAsync``1(System.Action{``0},Discord.RequestOptions)">
             <summary>
                 Modifies this <see cref="T:Discord.Rest.RestApplicationCommand"/>.
             </summary>

--- a/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
@@ -288,7 +288,7 @@ namespace Discord.Rest
         {
             var model = new ModifyApplicationCommandParams()
             {
-                Name = arg.Name.Value,
+                Name = arg.Name,
             };
 
             if (arg is SlashCommandProperties slashProps)

--- a/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
@@ -167,13 +167,15 @@ namespace Discord.Rest
         private static TArg GetApplicationCommandProperties<TArg>(IApplicationCommand command)
             where TArg : ApplicationCommandProperties
         {
+            bool isBaseClass = typeof(TArg) == typeof(ApplicationCommandProperties);
+
             switch (true)
             {
-                case true when typeof(TArg) == typeof(SlashCommandProperties) && command.Type == ApplicationCommandType.Slash:
+                case true when (typeof(TArg) == typeof(SlashCommandProperties) || isBaseClass) && command.Type == ApplicationCommandType.Slash:
                     return new SlashCommandProperties() as TArg;
-                case true when typeof(TArg) == typeof(MessageCommandProperties) && command.Type == ApplicationCommandType.Message:
+                case true when (typeof(TArg) == typeof(MessageCommandProperties) || isBaseClass) && command.Type == ApplicationCommandType.Message:
                     return new MessageCommandProperties() as TArg;
-                case true when typeof(TArg) == typeof(UserCommandProperties) && command.Type == ApplicationCommandType.User:
+                case true when (typeof(TArg) == typeof(UserCommandProperties) || isBaseClass) && command.Type == ApplicationCommandType.User:
                     return new UserCommandProperties() as TArg;
                 default:
                     throw new InvalidOperationException($"Cannot modify application command of type {command.Type} with the parameter type {typeof(TArg).FullName}");

--- a/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommand.cs
@@ -71,6 +71,12 @@ namespace Discord.Rest
         /// <inheritdoc/>
         public abstract Task DeleteAsync(RequestOptions options = null);
 
+        /// <inheritdoc />
+        public Task ModifyAsync(Action<ApplicationCommandProperties> func, RequestOptions options = null)
+        {
+            return ModifyAsync<ApplicationCommandProperties>(func, options);
+        }
+        
         /// <inheritdoc/>
         public abstract Task ModifyAsync<TArg>(Action<TArg> func, RequestOptions options = null)
             where TArg : ApplicationCommandProperties;

--- a/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommand.cs
@@ -57,6 +57,7 @@ namespace Discord.Rest
 
         internal virtual void Update(Model model)
         {
+            this.Type = model.Type;
             this.ApplicationId = model.ApplicationId;
             this.Name = model.Name;
             this.Description = model.Description;

--- a/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommand.cs
@@ -67,12 +67,12 @@ namespace Discord.Rest
                 : null;
         }
 
-
         /// <inheritdoc/>
         public abstract Task DeleteAsync(RequestOptions options = null);
 
         /// <inheritdoc/>
-        public abstract Task ModifyAsync(Action<ApplicationCommandProperties> func, RequestOptions options = null);
+        public abstract Task ModifyAsync<TArg>(Action<TArg> func, RequestOptions options = null)
+            where TArg : ApplicationCommandProperties;
 
         IReadOnlyCollection<IApplicationCommandOption> IApplicationCommand.Options => Options;
     }

--- a/src/Discord.Net.Rest/Entities/Interactions/RestGlobalCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestGlobalCommand.cs
@@ -37,9 +37,9 @@ namespace Discord.Rest
         /// <returns>
         ///     The modified command.
         /// </returns>
-        public override async Task ModifyAsync(Action<ApplicationCommandProperties> func, RequestOptions options = null)
+        public override async Task ModifyAsync<TArg>(Action<TArg> func, RequestOptions options = null)
         {
-            var cmd = await InteractionHelper.ModifyGlobalCommand(Discord, this, func, options).ConfigureAwait(false);
+            var cmd = await InteractionHelper.ModifyGlobalCommand<TArg>(Discord, this, func, options).ConfigureAwait(false);
             this.Update(cmd);
         }
     }

--- a/src/Discord.Net.Rest/Entities/Interactions/RestGuildCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestGuildCommand.cs
@@ -42,9 +42,9 @@ namespace Discord.Rest
         /// <returns>
         ///     The modified command
         /// </returns>
-        public override async Task ModifyAsync(Action<ApplicationCommandProperties> func, RequestOptions options = null)
+        public override async Task ModifyAsync<TArg>(Action<TArg> func, RequestOptions options = null)
         {
-            var model = await InteractionHelper.ModifyGuildCommand(Discord, this, GuildId, func, options).ConfigureAwait(false);
+            var model = await InteractionHelper.ModifyGuildCommand<TArg>(Discord, this, GuildId, func, options).ConfigureAwait(false);
             this.Update(model);
         }
 

--- a/src/Discord.Net.WebSocket/Discord.Net.WebSocket.xml
+++ b/src/Discord.Net.WebSocket/Discord.Net.WebSocket.xml
@@ -4022,16 +4022,11 @@
         <member name="M:Discord.WebSocket.SocketApplicationCommand.DeleteAsync(Discord.RequestOptions)">
             <inheritdoc/>
         </member>
+        <member name="M:Discord.WebSocket.SocketApplicationCommand.ModifyAsync(System.Action{Discord.ApplicationCommandProperties},Discord.RequestOptions)">
+            <inheritdoc />
+        </member>
         <member name="M:Discord.WebSocket.SocketApplicationCommand.ModifyAsync``1(System.Action{``0},Discord.RequestOptions)">
-            <summary>
-                Modifies the current application command.
-            </summary>
-            <param name="func">The new properties to use when modifying the command.</param>
-            <param name="options">The options to be used when sending the request.</param>
-            <returns>
-                A task that represents the asynchronous modification operation.
-            </returns>
-            <exception cref="T:System.InvalidOperationException">Thrown when you pass in an invalid <see cref="T:Discord.ApplicationCommandProperties"/> type.</exception>
+            <inheritdoc />
         </member>
         <member name="T:Discord.WebSocket.SocketApplicationCommandChoice">
             <summary>

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommand.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommand.cs
@@ -91,15 +91,13 @@ namespace Discord.WebSocket
         public Task DeleteAsync(RequestOptions options = null)
             => InteractionHelper.DeleteUnknownApplicationCommand(Discord, this.GuildId, this, options);
 
-        /// <summary>
-        ///     Modifies the current application command.
-        /// </summary>
-        /// <param name="func">The new properties to use when modifying the command.</param>
-        /// <param name="options">The options to be used when sending the request.</param>
-        /// <returns>
-        ///     A task that represents the asynchronous modification operation.
-        /// </returns>
-        /// <exception cref="InvalidOperationException">Thrown when you pass in an invalid <see cref="ApplicationCommandProperties"/> type.</exception>
+        /// <inheritdoc />
+        public Task ModifyAsync(Action<ApplicationCommandProperties> func, RequestOptions options = null)
+        {
+            return ModifyAsync<ApplicationCommandProperties>(func, options);
+        }
+        
+        /// <inheritdoc />
         public async Task ModifyAsync<TArg>(Action<TArg> func, RequestOptions options = null) where TArg : ApplicationCommandProperties
         {
             Model command = null;

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommand.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommand.cs
@@ -102,23 +102,15 @@ namespace Discord.WebSocket
         /// <exception cref="InvalidOperationException">Thrown when you pass in an invalid <see cref="ApplicationCommandProperties"/> type.</exception>
         public async Task ModifyAsync<TArg>(Action<TArg> func, RequestOptions options = null) where TArg : ApplicationCommandProperties
         {
-            switch (typeof(TArg))
-            {
-                case Type messageCommand when messageCommand == typeof(MessageCommandProperties) && this.Type != ApplicationCommandType.Message:
-                case Type slashCommand   when slashCommand   == typeof(SlashCommandProperties)   && this.Type != ApplicationCommandType.Slash:
-                case Type userCommand    when userCommand    == typeof(UserCommandProperties)    && this.Type != ApplicationCommandType.User:
-                    throw new InvalidOperationException($"Cannot modify this application command with the parameter type {nameof(TArg)}");
-            }
-
             Model command = null;
 
             if (this.IsGlobalCommand)
             {
-                command = await InteractionHelper.ModifyGlobalCommand(Discord, this, func, options).ConfigureAwait(false);
+                command = await InteractionHelper.ModifyGlobalCommand<TArg>(Discord, this, func, options).ConfigureAwait(false);
             }
             else
             {
-                command = await InteractionHelper.ModifyGuildCommand(Discord, this, this.GuildId.Value, func, options);
+                command = await InteractionHelper.ModifyGuildCommand<TArg>(Discord, this, this.GuildId.Value, func, options);
             }
 
             this.Update(command);
@@ -126,7 +118,5 @@ namespace Discord.WebSocket
 
         // IApplicationCommand
         IReadOnlyCollection<IApplicationCommandOption> IApplicationCommand.Options => Options;
-        Task IApplicationCommand.ModifyAsync(Action<ApplicationCommandProperties> func, RequestOptions options)
-            => ModifyAsync(func, options);
     }
 }


### PR DESCRIPTION
Possibly resolves #118.

I've taken first approach that I proposed in #118 as I found out that it was already like that in `SocketApplicationCommand`.

It could maybe still be better to also add the second level:
```cs
public interface IModifyApplicationCommand<T>
  where T : ApplicationCommandProperties
{
  public Task ModifyAsync<T>(Action<T> func, RequestOptions options = null);
}

public interface ISlashCommand : IModifyApplicationCommand<SlashCommandProperties> {}
public interface IUserCommand : IModifyApplicationCommand<UserCommandProperties> {}
public interface IMessageCommand : IModifyApplicationCommand<MessageCommandProperties> {}

RestSlashGuildCommand : RestGuildCommand, ISlashCommand
RestUserGuildCommand : RestGuildCommand, IUserCommand
RestMessageGuildCommand : RestGuildCommand, IMessageCommand

RestSlashGlobalCommand : RestGlobalCommand, ISlashCommand
RestUserGlobalCommand : RestGlobalCommand, IUserCommand
RestMessageGlobalCommand : RestGlobalCommand, IMessageCommand
```

Tell me if I should implement it. It would probably be needed for both socket and rest application commands.