### PR TITLE
Avoid description Preconditions for User/Message app commands

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/SlashCommandProperties.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/SlashCommandProperties.cs
@@ -15,7 +15,7 @@ namespace Discord
         /// <summary>
         ///    The discription of this command.
         /// </summary>
-        public Optional<string> Description { get; set; }
+        public string Description { get; set; }
 
         /// <summary>
         ///     Gets or sets the options for this command.

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -1142,8 +1142,6 @@ namespace Discord.API
             Preconditions.NotNull(command, nameof(command));
             Preconditions.AtMost(command.Name.Length, 32, nameof(command.Name));
             Preconditions.AtLeast(command.Name.Length, 3, nameof(command.Name));
-            Preconditions.AtMost(command.Description.Length, 100, nameof(command.Description));
-            Preconditions.AtLeast(command.Description.Length, 1, nameof(command.Description));
 
             options = RequestOptions.CreateOrClone(options);
 

--- a/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
@@ -73,8 +73,9 @@ namespace Discord.Rest
             if (arg is SlashCommandProperties slashProps)
             {
                 Preconditions.NotNullOrEmpty(slashProps.Description, nameof(slashProps.Description));
+                Preconditions.AtMost(slashProps.Description.Length, SlashCommandBuilder.MaxDescriptionLength, nameof(slashProps.Description));
 
-                model.Description = slashProps.Description.Value;
+                model.Description = slashProps.Description;
 
                 model.Options = slashProps.Options.IsSpecified
                     ? slashProps.Options.Value.Select(x => new Discord.API.ApplicationCommandOption(x)).ToArray()
@@ -108,8 +109,9 @@ namespace Discord.Rest
                 if (arg is SlashCommandProperties slashProps)
                 {
                     Preconditions.NotNullOrEmpty(slashProps.Description, nameof(slashProps.Description));
+                    Preconditions.AtMost(slashProps.Description.Length, SlashCommandBuilder.MaxDescriptionLength, nameof(slashProps.Description));
 
-                    model.Description = slashProps.Description.Value;
+                    model.Description = slashProps.Description;
 
                     model.Options = slashProps.Options.IsSpecified
                         ? slashProps.Options.Value.Select(x => new Discord.API.ApplicationCommandOption(x)).ToArray()
@@ -146,8 +148,9 @@ namespace Discord.Rest
                 if (arg is SlashCommandProperties slashProps)
                 {
                     Preconditions.NotNullOrEmpty(slashProps.Description, nameof(slashProps.Description));
+                    Preconditions.AtMost(slashProps.Description.Length, SlashCommandBuilder.MaxDescriptionLength, nameof(slashProps.Description));
 
-                    model.Description = slashProps.Description.Value;
+                    model.Description = slashProps.Description;
 
                     model.Options = slashProps.Options.IsSpecified
                         ? slashProps.Options.Value.Select(x => new Discord.API.ApplicationCommandOption(x)).ToArray()
@@ -188,11 +191,8 @@ namespace Discord.Rest
 
             if(args is SlashCommandProperties slashProps)
             {
-                if (slashProps.Description.IsSpecified)
-                {
-                    Preconditions.AtMost(slashProps.Description.Value.Length, 100, nameof(slashProps.Description));
-                    Preconditions.AtLeast(slashProps.Description.Value.Length, 1, nameof(slashProps.Description));
-                }
+                Preconditions.NotNullOrEmpty(slashProps.Description, nameof(slashProps.Description));
+                Preconditions.AtMost(slashProps.Description.Length, SlashCommandBuilder.MaxDescriptionLength, nameof(slashProps.Description));
 
                 if (slashProps.Options.IsSpecified)
                 {
@@ -244,8 +244,9 @@ namespace Discord.Rest
             if (arg is SlashCommandProperties slashProps)
             {
                 Preconditions.NotNullOrEmpty(slashProps.Description, nameof(slashProps.Description));
+                Preconditions.AtMost(slashProps.Description.Length, SlashCommandBuilder.MaxDescriptionLength, nameof(slashProps.Description));
 
-                model.Description = slashProps.Description.Value;
+                model.Description = slashProps.Description;
 
                 model.Options = slashProps.Options.IsSpecified
                     ? slashProps.Options.Value.Select(x => new Discord.API.ApplicationCommandOption(x)).ToArray()
@@ -278,8 +279,9 @@ namespace Discord.Rest
             if (arg is SlashCommandProperties slashProps)
             {
                 Preconditions.NotNullOrEmpty(slashProps.Description, nameof(slashProps.Description));
+                Preconditions.AtMost(slashProps.Description.Length, SlashCommandBuilder.MaxDescriptionLength, nameof(slashProps.Description));
 
-                model.Description = slashProps.Description.Value;
+                model.Description = slashProps.Description;
 
                 model.Options = slashProps.Options.IsSpecified
                     ? slashProps.Options.Value.Select(x => new Discord.API.ApplicationCommandOption(x)).ToArray()


### PR DESCRIPTION
Creating a user/message command will fail with an NRE as `DiscordRestApiClient` will try to validate the description length, even though the description isn't present for these commands.

```c#
await _discord.CreateGlobalApplicationCommandAsync(new MessageCommandProperties { Name = "Test" });
```