### PR TITLE
Cache unknown thread channel on THREAD_UPDATE

### DIFF
--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -603,13 +603,13 @@ namespace Discord.WebSocket
         /// <summary>
         ///     Fired when a thread is updated within a guild.
         /// </summary>
-        public event Func<SocketThreadChannel, SocketThreadChannel, Task> ThreadUpdated
+        public event Func<Cacheable<SocketThreadChannel, ulong>, SocketThreadChannel, Task> ThreadUpdated
         {
             add { _threadUpdated.Add(value); }
             remove { _threadUpdated.Remove(value); }
         }
 
-        internal readonly AsyncEvent<Func<SocketThreadChannel, SocketThreadChannel, Task>> _threadUpdated = new AsyncEvent<Func<SocketThreadChannel, SocketThreadChannel, Task>>();
+        internal readonly AsyncEvent<Func<Cacheable<SocketThreadChannel, ulong>, SocketThreadChannel, Task>> _threadUpdated = new();
 
         /// <summary>
         ///     Fired when a thread is deleted.


### PR DESCRIPTION
Cache unknown thread channel on THREAD_UPDATE

In the case where a thread is archived upon login, the thread channel is
not cached by the client. When the thread channel is unarchived, the
library simply outputs an unknown channel warning. When messages are
sent in the unarchived thread, the library won't have it cached and
will only output warnings.

This change makes it so the channel is cached when unarchived and
ThreadUpdated is invoked with an non specified "before" parameter. From
that point, the channel will be available for future events.