### PR TITLE
Property name: auto_archive_duration

### DIFF
--- a/src/Discord.Net.Rest/API/Rest/StartThreadParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/StartThreadParams.cs
@@ -12,7 +12,7 @@ namespace Discord.API.Rest
         [JsonProperty("name")]
         public string Name { get; set; }
 
-        [JsonProperty("duration")]
+        [JsonProperty("auto_archive_duration")]
         public ThreadArchiveDuration Duration { get; set; }
 
         [JsonProperty("type")]


### PR DESCRIPTION
According to [Discord Developer Portal](https://discord.com/developers/docs/resources/channel#start-thread-with-message), the property should be named `auto_archive_duration`, not just `duration`.

As of now, specifying `ThreadArchiveDuration` does not have effect on the duration of the thread, and only 24 hours is set.