### PR TITLE
Agument error corrections

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
@@ -45,7 +45,7 @@ namespace Discord
             set
             {
                 if (value?.Length > 100)
-                    throw new ArgumentException("Name length must be less than or equal to 32");
+                    throw new ArgumentException("Description length must be less than or equal to 100");
                 _description = value;
             }
         }

--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
@@ -46,6 +46,8 @@ namespace Discord
             {
                 if (value?.Length > 100)
                     throw new ArgumentException("Description length must be less than or equal to 100");
+                if (value?.Length < 1)
+                    throw new ArgumentException("Description length must at least 1 character in length");
                 _description = value;
             }
         }

--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOptionChoice.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOptionChoice.cs
@@ -30,12 +30,10 @@ namespace Discord
         }
 
         /// <summary>
-        /// <para>
         ///     The value of this choice.
-        ///</para>
-        /// <para>
-        ///     Discord only accepts int and string as the input.
-        ///</para>
+        ///     <note type="warning">
+        ///         Discord only accepts int and string as the input.
+        ///     </note>
         /// </summary>
         public object Value
         {

--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOptionChoice.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOptionChoice.cs
@@ -29,10 +29,13 @@ namespace Discord
             }
         }
 
-        // Note: discord allows strings & ints as values. how should that be handled?
-        // should we make this an object and then just type check it?
         /// <summary>
+        /// <para>
         ///     The value of this choice.
+        ///</para>
+        /// <para>
+        ///     Discord only accepts int and string as the input.
+        ///</para>
         /// </summary>
         public object Value
         {

--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOptionChoice.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOptionChoice.cs
@@ -23,6 +23,8 @@ namespace Discord
             {
                 if(value?.Length > 100)
                     throw new ArgumentException("Name length must be less than or equal to 100");
+                if (value?.Length < 1)
+                    throw new ArgumentException("Name length must at least 1 character in length");
                 _name = value;
             }
         }

--- a/src/Discord.Net.Core/Entities/Interactions/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/SlashCommandBuilder.cs
@@ -319,7 +319,7 @@ namespace Discord
                 if (value?.Length > SlashCommandBuilder.MaxDescriptionLength)
                     throw new ArgumentException($"Description length must be less than or equal to {SlashCommandBuilder.MaxDescriptionLength}");
                 if (value?.Length < 1)
-                    throw new ArgumentException("Name length must at least 1 character in length");
+                    throw new ArgumentException("Description length must at least 1 character in length");
 
                 _description = value;
             }

--- a/src/Discord.Net.Core/Entities/Interactions/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/SlashCommandBuilder.cs
@@ -296,7 +296,7 @@ namespace Discord
             set
             {
                 if (value?.Length > SlashCommandBuilder.MaxNameLength)
-                    throw new ArgumentException("Name length must be less than or equal to 32");
+                    throw new ArgumentException($"Name length must be less than or equal to {SlashCommandBuilder.MaxNameLength}");
                 if (value?.Length < 1)
                     throw new ArgumentException("Name length must at least 1 characters in length");
 
@@ -317,7 +317,7 @@ namespace Discord
             set
             {
                 if (value?.Length > SlashCommandBuilder.MaxDescriptionLength)
-                    throw new ArgumentException("Description length must be less than or equal to 100");
+                    throw new ArgumentException($"Description length must be less than or equal to {SlashCommandBuilder.MaxDescriptionLength}");
                 if (value?.Length < 1)
                     throw new ArgumentException("Name length must at least 1 character in length");
 


### PR DESCRIPTION
Changed arguments to use the variables for errors.
Changed name to description on error ArgumentException where they were incorrectly set as name.
Added value?.Length < 1 for Name and Description where they were missing.
Change para to <note type="warning"> for Value.