### PR TITLE
Fixed Placement of Obsolete on InteractionResponseType

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/InteractionResponseType.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/InteractionResponseType.cs
@@ -22,16 +22,16 @@ namespace Discord
         /// </summary>
         Pong = 1,
 
-        [Obsolete("This response type has been depricated by discord. Either use ChannelMessageWithSource or DeferredChannelMessageWithSource", true)]
         /// <summary>
         ///     ACK a command without sending a message, eating the user's input.
         /// </summary>
+        [Obsolete("This response type has been depricated by discord. Either use ChannelMessageWithSource or DeferredChannelMessageWithSource", true)]
         Acknowledge = 2,
 
-        [Obsolete("This response type has been depricated by discord. Either use ChannelMessageWithSource or DeferredChannelMessageWithSource", true)]
         /// <summary>
         ///     Respond with a message, showing the user's input.
         /// </summary>
+        [Obsolete("This response type has been depricated by discord. Either use ChannelMessageWithSource or DeferredChannelMessageWithSource", true)]
         ChannelMessage = 3,
 
         /// <summary>


### PR DESCRIPTION
Fixed Missing XML comment for publicly visible type or member 'InteractionResponseType.Acknowledge'
Fixed Missing XML comment for publicly visible type or member 'InteractionResponseType.ChannelMessage'