### PR TITLE
Grammar fix bulk-overwrite-of-global-slash-commands.md

### DIFF
--- a/docs/guides/interactions/application-commands/slash-commands/08-bulk-overwrite-of-global-slash-commands.md
+++ b/docs/guides/interactions/application-commands/slash-commands/08-bulk-overwrite-of-global-slash-commands.md
@@ -1,4 +1,4 @@
-If you have too many global commands then you might want to consider doing a bulk overwrite.
+If you have too many global commands then you might want to consider using the bulk overwrite function.
 ```cs
 public async Task Client_Ready() {
     List<ApplicationCommandProperties> applicationCommandProperties = new();


### PR DESCRIPTION
Just fixes the grammar of the bulk-overwrite-of-global-slash-commands.md