### PR TITLE
Fix thread permissions

### DIFF
--- a/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildPermissions.cs
@@ -93,6 +93,10 @@ namespace Discord
         public bool CreatePublicThreads => Permissions.GetValue(RawValue, GuildPermission.CreatePublicThreads);
         /// <summary> If <c>true</c>, a user may create private threads in this guild. </summary>
         public bool CreatePrivateThreads => Permissions.GetValue(RawValue, GuildPermission.CreatePrivateThreads);
+        /// <summary> If <c>true</c>, a user may use public threads in this guild. </summary>
+        public bool UsePublicThreads => Permissions.GetValue(RawValue, GuildPermission.UsePublicThreads);
+        /// <summary> If <c>true</c>, a user may use private threads in this guild. </summary>
+        public bool UsePrivateThreads => Permissions.GetValue(RawValue, GuildPermission.UsePrivateThreads);
         /// <summary> If <c>true</c>, a user may use external stickers in this guild. </summary>
         public bool UseExternalStickers => Permissions.GetValue(RawValue, GuildPermission.UseExternalStickers);
         /// <summary> If <c>true</c>, a user may send messages in threads in this guild. </summary>
@@ -143,6 +147,8 @@ namespace Discord
             bool? manageThreads = null,
             bool? createPublicThreads = null,
             bool? createPrivateThreads = null,
+            bool? usePublicThreads = null,
+            bool? usePrivateThreads = null,
             bool? useExternalStickers = null,
             bool? sendMessagesInThreads = null,
             bool? startEmbeddedActivities = null)
@@ -185,6 +191,8 @@ namespace Discord
             Permissions.SetValue(ref value, manageThreads, GuildPermission.ManageThreads);
             Permissions.SetValue(ref value, createPublicThreads, GuildPermission.CreatePublicThreads);
             Permissions.SetValue(ref value, createPrivateThreads, GuildPermission.CreatePrivateThreads);
+            Permissions.SetValue(ref value, usePublicThreads, GuildPermission.UsePublicThreads);
+            Permissions.SetValue(ref value, usePrivateThreads, GuildPermission.UsePrivateThreads);
             Permissions.SetValue(ref value, useExternalStickers, GuildPermission.UseExternalStickers);
             Permissions.SetValue(ref value, sendMessagesInThreads, GuildPermission.SendMessagesInThreads);
             Permissions.SetValue(ref value, startEmbeddedActivities, GuildPermission.StartEmbeddedActivities);
@@ -230,6 +238,8 @@ namespace Discord
             bool manageThreads = false,
             bool createPublicThreads = false,
             bool createPrivateThreads = false,
+            bool usePublicThreads = false,
+            bool usePrivateThreads = false,
             bool useExternalStickers = false,
             bool sendMessagesInThreads = false,
             bool startEmbeddedActivities = false)
@@ -270,6 +280,8 @@ namespace Discord
                 manageThreads: manageThreads,
                 createPublicThreads: createPublicThreads,
                 createPrivateThreads: createPrivateThreads,
+                usePublicThreads: usePublicThreads,
+                usePrivateThreads: usePrivateThreads,
 				useExternalStickers: useExternalStickers,
                 sendMessagesInThreads: sendMessagesInThreads,
                 startEmbeddedActivities: startEmbeddedActivities)
@@ -313,6 +325,8 @@ namespace Discord
             bool? manageThreads = null,
             bool? createPublicThreads = null,
             bool? createPrivateThreads = null,
+            bool? usePublicThreads = null,
+            bool? usePrivateThreads = null,
             bool? useExternalStickers = null,
             bool? sendMessagesInThreads = null,
             bool? startEmbeddedActivities = null)
@@ -320,7 +334,7 @@ namespace Discord
                 viewAuditLog, viewGuildInsights, viewChannel, sendMessages, sendTTSMessages, manageMessages, embedLinks, attachFiles,
                 readMessageHistory, mentionEveryone, useExternalEmojis, connect, speak, muteMembers, deafenMembers, moveMembers,
                 useVoiceActivation, prioritySpeaker, stream, changeNickname, manageNicknames, manageRoles, manageWebhooks, manageEmojisAndStickers,
-                useSlashCommands, requestToSpeak, manageThreads, createPublicThreads, createPrivateThreads, useExternalStickers, sendMessagesInThreads,
+                useSlashCommands, requestToSpeak, manageThreads, createPublicThreads, createPrivateThreads, usePublicThreads, usePrivateThreads, useExternalStickers, sendMessagesInThreads,
                 startEmbeddedActivities);
 
         /// <summary>

--- a/test/Discord.Net.Tests.Unit/GuildPermissionsTests.cs
+++ b/test/Discord.Net.Tests.Unit/GuildPermissionsTests.cs
@@ -95,8 +95,8 @@ namespace Discord
             AssertFlag(() => new GuildPermissions(useSlashCommands: true), GuildPermission.UseSlashCommands);
             AssertFlag(() => new GuildPermissions(requestToSpeak: true), GuildPermission.RequestToSpeak);
             AssertFlag(() => new GuildPermissions(manageThreads: true), GuildPermission.ManageThreads);
-            AssertFlag(() => new GuildPermissions(usePublicThreads: true), GuildPermission.UsePublicThreads);
-            AssertFlag(() => new GuildPermissions(usePrivateThreads: true), GuildPermission.UsePrivateThreads);
+            AssertFlag(() => new GuildPermissions(createPublicThreads: true), GuildPermission.CreatePublicThreads);
+            AssertFlag(() => new GuildPermissions(createPrivateThreads: true), GuildPermission.CreatePrivateThreads);
             AssertFlag(() => new GuildPermissions(useExternalStickers: true), GuildPermission.UseExternalStickers);
         }
 
@@ -171,8 +171,8 @@ namespace Discord
             AssertUtil(GuildPermission.UseSlashCommands, x => x.UseSlashCommands, (p, enable) => p.Modify(useSlashCommands: enable));
             AssertUtil(GuildPermission.RequestToSpeak, x => x.RequestToSpeak, (p, enable) => p.Modify(requestToSpeak: enable));
             AssertUtil(GuildPermission.ManageThreads, x => x.ManageThreads, (p, enable) => p.Modify(manageThreads: enable));
-            AssertUtil(GuildPermission.UsePublicThreads, x => x.UsePublicThreads, (p, enable) => p.Modify(usePublicThreads: enable));
-            AssertUtil(GuildPermission.UsePrivateThreads, x => x.UsePrivateThreads, (p, enable) => p.Modify(usePrivateThreads: enable));
+            AssertUtil(GuildPermission.CreatePublicThreads, x => x.CreatePublicThreads, (p, enable) => p.Modify(createPublicThreads: enable));
+            AssertUtil(GuildPermission.CreatePrivateThreads, x => x.CreatePrivateThreads, (p, enable) => p.Modify(createPrivateThreads: enable));
             AssertUtil(GuildPermission.UseExternalStickers, x => x.UseExternalStickers, (p, enable) => p.Modify(useExternalStickers: enable));
         }
     }


### PR DESCRIPTION
Re-adds UsePublicThreads and UsePrivateThreads to prevent breaking changes and provide an obsolete warning while trying to use the old permission nodes.