### PR TITLE
Change Minimum Slash Command Name Length to 1 per Discord API docs

### DIFF
--- a/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
@@ -195,7 +195,7 @@ namespace Discord.Rest
             if (args.Name.IsSpecified)
             {
                 Preconditions.AtMost(args.Name.Value.Length, 32, nameof(args.Name));
-                Preconditions.AtLeast(args.Name.Value.Length, 3, nameof(args.Name));
+                Preconditions.AtLeast(args.Name.Value.Length, 1, nameof(args.Name));
             }
 
             var model = new Discord.API.Rest.ModifyApplicationCommandParams()


### PR DESCRIPTION
Discord used to have a minimum of 3 characters for an application command `name`, but it has since been updated to be only 1. I found this when trying to make a 2 character command name. I was able to do it using Discord.js.

![image](https://user-images.githubusercontent.com/16886888/134790028-7eec93ae-9012-4904-8e83-9fc2c6d93c43.png)