### PR TITLE
Removed style of the nuget badge and added logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Discord.Net Labs
-[![NuGet](https://img.shields.io/nuget/vpre/Discord.Net.Labs.svg?maxAge=2592000?style=plastic)](https://www.nuget.org/packages/Discord.Net.Labs)
+[![NuGet](https://img.shields.io/nuget/vpre/Discord.Net.Labs.svg?maxAge=2592000&logo=nuget)](https://www.nuget.org/packages/Discord.Net.Labs)
 [![Discord](https://discord.com/api/guilds/848176216011046962/widget.png)](https://discord.gg/dvSfUTet3K)
 
 This repo is a custom fork of Discord.Net that introduces the newest features of discord for testing and experimenting. Nothing here is guaranteed to work but you are more than welcome to submit bugs in the issues tabs


### PR DESCRIPTION
The style was not properly added to it and the plastic version does not look good with the discord badge.
I thought it would look better with a logo.