### PR TITLE
Add Icons to IRole

### DIFF
--- a/src/Discord.Net.Core/CDN.cs
+++ b/src/Discord.Net.Core/CDN.cs
@@ -86,6 +86,16 @@ namespace Discord
         public static string GetGuildIconUrl(ulong guildId, string iconId)
             => iconId != null ? $"{DiscordConfig.CDNUrl}icons/{guildId}/{iconId}.jpg" : null;
         /// <summary>
+        ///     Returns a guild role's icon URL.
+        /// </summary>
+        /// <param name="roleId">The role identifier.</param>
+        /// <param name="roleHash">The icon hash.</param>
+        /// <returns>
+        ///     A URL pointing to the guild role's icon.
+        /// </returns>
+        public static string GetGuildRoleIconUrl(ulong roleId, string roleHash)
+            => roleHash != null ? $"{DiscordConfig.CDNUrl}role-icons/{roleId}/{roleHash}.png" : null;
+        /// <summary>
         ///     Returns a guild splash URL.
         /// </summary>
         /// <param name="guildId">The guild snowflake identifier.</param>

--- a/src/Discord.Net.Core/Discord.Net.Core.xml
+++ b/src/Discord.Net.Core/Discord.Net.Core.xml
@@ -131,6 +131,16 @@
                 A URL pointing to the guild's icon.
             </returns>
         </member>
+        <member name="M:Discord.CDN.GetGuildRoleIconUrl(System.UInt64,System.String)">
+            <summary>
+                Returns a guild role's icon URL.
+            </summary>
+            <param name="roleId">The role identifier.</param>
+            <param name="roleHash">The icon hash.</param>
+            <returns>
+                A URL pointing to the guild role's icon.
+            </returns>
+        </member>
         <member name="M:Discord.CDN.GetGuildSplashUrl(System.UInt64,System.String)">
             <summary>
                 Returns a guild splash URL.
@@ -9682,6 +9692,14 @@
             <param name="options">The options to be used when sending the request.</param>
             <returns>
                 A task that represents the asynchronous modification operation.
+            </returns>
+        </member>
+        <member name="M:Discord.IRole.GetIconUrl">
+            <summary>
+                Gets the image url of the icon role.
+            </summary>
+            <returns>
+                An image url of the icon role.
             </returns>
         </member>
         <member name="T:Discord.ReorderRoleProperties">

--- a/src/Discord.Net.Core/Discord.Net.Core.xml
+++ b/src/Discord.Net.Core/Discord.Net.Core.xml
@@ -9638,6 +9638,14 @@
                 A string containing the name of this role.
             </returns>
         </member>
+        <member name="P:Discord.IRole.Icon">
+            <summary>
+                Gets the icon of this role.
+            </summary>
+            <returns>
+                A string containing the hash of this role's icon.
+            </returns>
+        </member>
         <member name="P:Discord.IRole.Permissions">
             <summary>
                 Gets the permissions granted to members of this role.

--- a/src/Discord.Net.Core/Entities/Roles/IRole.cs
+++ b/src/Discord.Net.Core/Entities/Roles/IRole.cs
@@ -93,5 +93,13 @@ namespace Discord
         ///     A task that represents the asynchronous modification operation.
         /// </returns>
         Task ModifyAsync(Action<RoleProperties> func, RequestOptions options = null);
+
+        /// <summary>
+        ///     Gets the image url of the icon role.
+        /// </summary>
+        /// <returns>
+        ///     An image url of the icon role.
+        /// </returns>
+        string GetIconUrl();
     }
 }

--- a/src/Discord.Net.Core/Entities/Roles/IRole.cs
+++ b/src/Discord.Net.Core/Entities/Roles/IRole.cs
@@ -52,6 +52,13 @@ namespace Discord
         /// </returns>
         string Name { get; }
         /// <summary>
+        ///     Gets the icon of this role.
+        /// </summary>
+        /// <returns>
+        ///     A string containing the hash of this role's icon.
+        /// </returns>
+        string Icon { get; }
+        /// <summary>
         ///     Gets the permissions granted to members of this role.
         /// </summary>
         /// <returns>

--- a/src/Discord.Net.Rest/API/Common/Role.cs
+++ b/src/Discord.Net.Rest/API/Common/Role.cs
@@ -8,6 +8,8 @@ namespace Discord.API
         public ulong Id { get; set; }
         [JsonProperty("name")]
         public string Name { get; set; }
+        [JsonProperty("icon")]
+        public string Icon { get; set; }
         [JsonProperty("color")]
         public uint Color { get; set; }
         [JsonProperty("hoist")]

--- a/src/Discord.Net.Rest/Discord.Net.Rest.xml
+++ b/src/Discord.Net.Rest/Discord.Net.Rest.xml
@@ -4613,6 +4613,9 @@
         <member name="P:Discord.Rest.RestRole.Name">
             <inheritdoc />
         </member>
+        <member name="P:Discord.Rest.RestRole.Icon">
+            <inheritdoc />
+        </member>
         <member name="P:Discord.Rest.RestRole.Permissions">
             <inheritdoc />
         </member>

--- a/src/Discord.Net.Rest/Discord.Net.Rest.xml
+++ b/src/Discord.Net.Rest/Discord.Net.Rest.xml
@@ -4642,6 +4642,9 @@
         <member name="M:Discord.Rest.RestRole.DeleteAsync(Discord.RequestOptions)">
             <inheritdoc />
         </member>
+        <member name="M:Discord.Rest.RestRole.GetIconUrl">
+            <inheritdoc />
+        </member>
         <member name="M:Discord.Rest.RestRole.CompareTo(Discord.IRole)">
             <inheritdoc />
         </member>

--- a/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
@@ -24,6 +24,8 @@ namespace Discord.Rest
         /// <inheritdoc />
         public string Name { get; private set; }
         /// <inheritdoc />
+        public string Icon { get; private set; }
+        /// <inheritdoc />
         public GuildPermissions Permissions { get; private set; }
         /// <inheritdoc />
         public int Position { get; private set; }
@@ -53,6 +55,7 @@ namespace Discord.Rest
         internal void Update(Model model)
         {
             Name = model.Name;
+            Icon = model.Icon;
             IsHoisted = model.Hoist;
             IsManaged = model.Managed;
             IsMentionable = model.Mentionable;

--- a/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
+++ b/src/Discord.Net.Rest/Entities/Roles/RestRole.cs
@@ -77,6 +77,10 @@ namespace Discord.Rest
             => RoleHelper.DeleteAsync(this, Discord, options);
 
         /// <inheritdoc />
+        public string GetIconUrl()
+            => CDN.GetGuildRoleIconUrl(Id, Icon);
+
+        /// <inheritdoc />
         public int CompareTo(IRole role) => RoleUtils.Compare(this, role);
 
         /// <summary>

--- a/src/Discord.Net.WebSocket/Discord.Net.WebSocket.xml
+++ b/src/Discord.Net.WebSocket/Discord.Net.WebSocket.xml
@@ -4880,6 +4880,9 @@
         <member name="M:Discord.WebSocket.SocketRole.DeleteAsync(Discord.RequestOptions)">
             <inheritdoc />
         </member>
+        <member name="M:Discord.WebSocket.SocketRole.GetIconUrl">
+            <inheritdoc />
+        </member>
         <member name="M:Discord.WebSocket.SocketRole.ToString">
             <summary>
                 Gets the name of the role.

--- a/src/Discord.Net.WebSocket/Discord.Net.WebSocket.xml
+++ b/src/Discord.Net.WebSocket/Discord.Net.WebSocket.xml
@@ -4843,6 +4843,9 @@
         <member name="P:Discord.WebSocket.SocketRole.Name">
             <inheritdoc />
         </member>
+        <member name="P:Discord.WebSocket.SocketRole.Icon">
+            <inheritdoc />
+        </member>
         <member name="P:Discord.WebSocket.SocketRole.Permissions">
             <inheritdoc />
         </member>

--- a/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
+++ b/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
@@ -34,6 +34,8 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         public string Name { get; private set; }
         /// <inheritdoc />
+        public string Icon { get; private set; }
+        /// <inheritdoc />
         public GuildPermissions Permissions { get; private set; }
         /// <inheritdoc />
         public int Position { get; private set; }
@@ -72,6 +74,7 @@ namespace Discord.WebSocket
         internal void Update(ClientState state, Model model)
         {
             Name = model.Name;
+            Icon = model.Icon;
             IsHoisted = model.Hoist;
             IsManaged = model.Managed;
             IsMentionable = model.Mentionable;

--- a/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
+++ b/src/Discord.Net.WebSocket/Entities/Roles/SocketRole.cs
@@ -92,6 +92,10 @@ namespace Discord.WebSocket
         public Task DeleteAsync(RequestOptions options = null)
             => RoleHelper.DeleteAsync(this, Discord, options);
 
+        /// <inheritdoc />
+        public string GetIconUrl()
+            => CDN.GetGuildRoleIconUrl(Id, Icon);
+
         /// <summary>
         ///     Gets the name of the role.
         /// </summary>


### PR DESCRIPTION
Discord started rolling out role icons to community boosted servers today. This exposes the icon hash to an IRole (`role.Icon`), and a `GetIconUrl()` to get the direct image link.

Here's an example of posting the icon hash, icon direct image link, and link example for my role.

![image](https://user-images.githubusercontent.com/16886888/135147522-788a48c7-4259-4c1c-89b8-cc7a66e09ef7.png)
