### PR TITLE
Added autocomplete in SlashCommandOptionBuilder.

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/Slash Commands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Slash Commands/SlashCommandBuilder.cs
@@ -12,15 +12,15 @@ namespace Discord
     /// </summary>
     public class SlashCommandBuilder
     {
-        /// <summary> 
+        /// <summary>
         ///     Returns the maximun length a commands name allowed by Discord
         /// </summary>
         public const int MaxNameLength = 32;
-        /// <summary> 
-        ///     Returns the maximum length of a commands description allowed by Discord. 
+        /// <summary>
+        ///     Returns the maximum length of a commands description allowed by Discord.
         /// </summary>
         public const int MaxDescriptionLength = 100;
-        /// <summary> 
+        /// <summary>
         ///     Returns the maximum count of command options allowed by Discord
         /// </summary>
         public const int MaxOptionsCount = 25;
@@ -396,11 +396,12 @@ namespace Discord
         /// <param name="description">The description of this option.</param>
         /// <param name="required">If this option is required for this command.</param>
         /// <param name="isDefault">If this option is the default option.</param>
+        /// <param name="isAutocomplete">If this option supports autocomplete.</param>
         /// <param name="options">The options of the option to add.</param>
         /// <param name="choices">The choices of this option.</param>
         /// <returns>The current builder.</returns>
         public SlashCommandOptionBuilder AddOption(string name, ApplicationCommandOptionType type,
-           string description, bool? required = null, bool isDefault = false, List<SlashCommandOptionBuilder> options = null, params ApplicationCommandOptionChoiceProperties[] choices)
+           string description, bool? required = null, bool isDefault = false, bool isAutocomplete = false, List<SlashCommandOptionBuilder> options = null, params ApplicationCommandOptionChoiceProperties[] choices)
         {
             // Make sure the name matches the requirements from discord
             Preconditions.NotNullOrEmpty(name, nameof(name));
@@ -431,6 +432,7 @@ namespace Discord
                 Description = description,
                 Required = required,
                 Default = isDefault,
+                Autocomplete = isAutocomplete,
                 Options = options,
                 Type = type,
                 Choices = choices != null ? new List<ApplicationCommandOptionChoiceProperties>(choices) : null
@@ -564,6 +566,17 @@ namespace Discord
         public SlashCommandOptionBuilder WithDefault(bool value)
         {
             Default = value;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets the current builders autocomplete support.
+        /// </summary>
+        /// <param name="value">The value to set.</param>
+        /// <returns>The current builder.</returns>
+        public SlashCommandOptionBuilder WithAutocomplete(bool value)
+        {
+            Autocomplete = value;
             return this;
         }
 


### PR DESCRIPTION
Added `bool isAutocomplete = false` in `AddOption()`.
Added method `WithAutocomplete(bool)`.

Probably just missed. I decided that it should not be so because it leads to strange behavior of the builder:
![image](https://user-images.githubusercontent.com/6567597/135341192-b7174f68-905f-41bb-a876-53d5eab083df.png)
