### PR TITLE
Support the discord:// protocol in buttons

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/Message Components/ComponentBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Message Components/ComponentBuilder.cs
@@ -596,7 +596,7 @@ namespace Discord
                 if (string.IsNullOrEmpty(Url))
                     throw new InvalidOperationException("Link buttons must have a link associated with them");
                 else
-                    UrlValidation.Validate(Url);
+                    UrlValidation.ValidateButton(Url);
             }
             else if (string.IsNullOrEmpty(CustomId))
                 throw new InvalidOperationException("Non-link buttons must have a custom id associated with them");

--- a/src/Discord.Net.Core/Utils/UrlValidation.cs
+++ b/src/Discord.Net.Core/Utils/UrlValidation.cs
@@ -18,5 +18,16 @@ namespace Discord.Utils
                 throw new InvalidOperationException($"Url {url} must be include its protocol (either HTTP or HTTPS)");
             return true;
         }
+        
+        public static bool ValidateButton(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+                return false;
+            if(!((url.StartsWith("http://", StringComparison.OrdinalIgnoreCase)) || 
+                (url.StartsWith("https://", StringComparison.OrdinalIgnoreCase)) || 
+                (url.StartsWith("discord://", StringComparison.OrdinalIgnoreCase))))
+                throw new InvalidOperationException($"Url {url} must be include its protocol (either HTTP, HTTPS, or DISCORD)");
+            return true;
+        }
     }
 }

--- a/src/Discord.Net.Core/Utils/UrlValidation.cs
+++ b/src/Discord.Net.Core/Utils/UrlValidation.cs
@@ -6,6 +6,7 @@ namespace Discord.Utils
     {
         /// <summary>
         /// Not full URL validation right now. Just ensures protocol is present and that it's either http or https
+        /// <see cref="ValidateButton(string)"/> should be used for url buttons
         /// </summary>
         /// <param name="url">url to validate before sending to Discord.</param>
         /// <exception cref="InvalidOperationException">A URL must include a protocol (http or https).</exception>
@@ -15,18 +16,25 @@ namespace Discord.Utils
             if (string.IsNullOrEmpty(url))
                 return false;
             if(!(url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) || (url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))))
-                throw new InvalidOperationException($"Url {url} must be include its protocol (either HTTP or HTTPS)");
+                throw new InvalidOperationException($"The url {url} must include a protocol (either HTTP or HTTPS)");
             return true;
         }
-        
+
+        /// <summary>
+        /// Not full URL validation right now. Just Ensures the protocol is either http, https, or discord
+        /// <see cref="Validate(string)"/> should be used everything other than url buttons
+        /// </summary>
+        /// <param name="url">the url to validate before sending to discord</param>
+        /// <exception cref="InvalidOperationException">A URL must include a protocol (either http, httpd, or discord).</exception>
+        /// <returns>true if the url is valid by our standard, false if null, throws an error upon invalid</returns>
         public static bool ValidateButton(string url)
-        {
+       {
             if (string.IsNullOrEmpty(url))
                 return false;
             if(!((url.StartsWith("http://", StringComparison.OrdinalIgnoreCase)) || 
                 (url.StartsWith("https://", StringComparison.OrdinalIgnoreCase)) || 
                 (url.StartsWith("discord://", StringComparison.OrdinalIgnoreCase))))
-                throw new InvalidOperationException($"Url {url} must be include its protocol (either HTTP, HTTPS, or DISCORD)");
+                throw new InvalidOperationException($"The url {url} must include a protocol (either HTTP, HTTPS, or DISCORD)");
             return true;
         }
     }

--- a/src/Discord.Net.Core/Utils/UrlValidation.cs
+++ b/src/Discord.Net.Core/Utils/UrlValidation.cs
@@ -25,10 +25,10 @@ namespace Discord.Utils
         /// <see cref="Validate(string)"/> should be used everything other than url buttons
         /// </summary>
         /// <param name="url">the url to validate before sending to discord</param>
-        /// <exception cref="InvalidOperationException">A URL must include a protocol (either http, httpd, or discord).</exception>
+        /// <exception cref="InvalidOperationException">A URL must include a protocol (either http, https, or discord).</exception>
         /// <returns>true if the url is valid by our standard, false if null, throws an error upon invalid</returns>
         public static bool ValidateButton(string url)
-       {
+        {
             if (string.IsNullOrEmpty(url))
                 return false;
             if(!((url.StartsWith("http://", StringComparison.OrdinalIgnoreCase)) || 


### PR DESCRIPTION
Support the `discord://` protocol in buttons, as per https://github.com/discord/discord-api-docs/discussions/3347,
this pr creates the method `UrlValidation.ValidateButton` and uses it when validating button URLs.