### PR TITLE
Better errors

### DIFF
--- a/src/Discord.Net.Core/Discord.Net.Core.xml
+++ b/src/Discord.Net.Core/Discord.Net.Core.xml
@@ -5976,7 +5976,8 @@
         </member>
         <member name="P:Discord.SlashCommandBuilder.Description">
             <summary>
-               A 1-100 length description of this slash command
+               A 1-100 length description of this slash command.
+               The description is not allowed to be null.
             </summary>
         </member>
         <member name="P:Discord.SlashCommandBuilder.Options">

--- a/src/Discord.Net.Core/JsonErrorCode.cs
+++ b/src/Discord.Net.Core/JsonErrorCode.cs
@@ -50,7 +50,7 @@ namespace Discord
         UnknownGuildMemberVerificationForm = 10068,
         UnknownGuildWelcomeScreen = 10069,
         UnknownGuildScheduledEvent = 10070,
-        UnknownGuildScheduledEventUser = 10071
+        UnknownGuildScheduledEventUser = 10071,
         #endregion
 
         #region General Actions (20XXX)

--- a/src/Discord.Net.Rest/API/Common/DiscordError.cs
+++ b/src/Discord.Net.Rest/API/Common/DiscordError.cs
@@ -9,6 +9,7 @@ namespace Discord.API
 {
     internal class DiscordError
     {
+        //
         [JsonProperty("message")]
         public string Message { get; set; }
         [JsonProperty("code")]

--- a/src/Discord.Net.Rest/API/Exceptions/BadRequestException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/BadRequestException.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Discord.Rest.API
+namespace Discord.Rest.Exceptions
 {
     class BadRequestException
     {        

--- a/src/Discord.Net.Rest/API/Exceptions/BadRequestException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/BadRequestException.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord.Rest.API
+{
+    class BadRequestException
+    {        
+    }
+}

--- a/src/Discord.Net.Rest/API/Exceptions/GeneralActionException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/GeneralActionException.cs
@@ -6,7 +6,8 @@ using System.Threading.Tasks;
 
 namespace Discord.Rest.Exceptions
 {
-    class BadRequestException
-    {        
+    public class GeneralActionException : Exception
+    {
+
     }
 }

--- a/src/Discord.Net.Rest/API/Exceptions/GeneralRequestException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/GeneralRequestException.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Discord.API.Rest;
+using Discord.API;
+
+namespace Discord.Rest.Exceptions    
+{
+    public class GeneralRequestException : Exception
+    {
+        internal GeneralRequestException(string json, DiscordError value)
+        {
+            
+        }
+    }
+}

--- a/src/Discord.Net.Rest/API/Exceptions/GenericJsonException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/GenericJsonException.cs
@@ -7,19 +7,19 @@ using System.Threading.Tasks;
 namespace Discord.Rest.Exceptions
 {
     //Visual studio wont allow 2FAException??
-    class MFAException
+    class MFAException : Exception
     {
     }
-    class UserSearchException
+    class UserSearchException : Exception
     {
     }
-    class ReactionException
+    class ReactionException : Exception
     {
     }
-    class APIException
+    class APIException : Exception
     {
     }
-    class StageException
+    class StageException : Exception
     {        
     }
 }

--- a/src/Discord.Net.Rest/API/Exceptions/GenericJsonException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/GenericJsonException.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Discord.Rest.API
+namespace Discord.Rest.Exceptions
 {
     //Visual studio wont allow 2FAException??
     class MFAException

--- a/src/Discord.Net.Rest/API/Exceptions/GenericJsonException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/GenericJsonException.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord.Rest.API
+{
+    //Visual studio wont allow 2FAException??
+    class MFAException
+    {
+    }
+    class UserSearchException
+    {
+    }
+    class ReactionException
+    {
+    }
+    class APIException
+    {
+    }
+    class StageException
+    {        
+    }
+}

--- a/src/Discord.Net.Rest/API/Exceptions/LimitReachedException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/LimitReachedException.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Discord.Rest.API
+namespace Discord.Rest.Exceptions
 {
     class LimitReachedException
     {

--- a/src/Discord.Net.Rest/API/Exceptions/LimitReachedException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/LimitReachedException.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Discord.Rest.Exceptions
 {
-    class LimitReachedException
+    class LimitReachedException : Exception
     {
     }
 }

--- a/src/Discord.Net.Rest/API/Exceptions/LimitReachedException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/LimitReachedException.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord.Rest.API
+{
+    class LimitReachedException
+    {
+    }
+}

--- a/src/Discord.Net.Rest/API/Exceptions/PreconditionException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/PreconditionException.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Discord.Rest.API
+namespace Discord.Rest.Exceptions
 {
     class PrecondionException
     {

--- a/src/Discord.Net.Rest/API/Exceptions/PreconditionException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/PreconditionException.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Discord.Rest.Exceptions
 {
-    class PrecondionException
+    class PrecondionException : Exception
     {
     }
 }

--- a/src/Discord.Net.Rest/API/Exceptions/PreconditionException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/PreconditionException.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord.Rest.API
+{
+    class PrecondionException
+    {
+    }
+}

--- a/src/Discord.Net.Rest/API/Exceptions/ReplyAndThreadException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/ReplyAndThreadException.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Discord.Rest.Exceptions
 {
-    class ReplyAndThreadException
+    class ReplyAndThreadException : Exception
     {
     }
 }

--- a/src/Discord.Net.Rest/API/Exceptions/ReplyAndThreadException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/ReplyAndThreadException.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord.Rest.API
+{
+    class ReplyAndThreadException
+    {
+    }
+}

--- a/src/Discord.Net.Rest/API/Exceptions/ReplyAndThreadException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/ReplyAndThreadException.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Discord.Rest.API
+namespace Discord.Rest.Exceptions
 {
     class ReplyAndThreadException
     {

--- a/src/Discord.Net.Rest/API/Exceptions/StickerException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/StickerException.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Discord.Rest.API
+namespace Discord.Rest.Exceptions
 {
     class StickerException
     {

--- a/src/Discord.Net.Rest/API/Exceptions/StickerException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/StickerException.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Discord.Rest.Exceptions
 {
-    class StickerException
+    class StickerException : Exception
     {
     }
 }

--- a/src/Discord.Net.Rest/API/Exceptions/StickerException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/StickerException.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord.Rest.API
+{
+    class StickerException
+    {
+    }
+}

--- a/src/Discord.Net.Rest/API/Exceptions/UnknownEntitieException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/UnknownEntitieException.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Discord.Rest.Exceptions
 {
-    class UnknownEntitieException
+    class UnknownEntitieException : Exception
     {
     }
 }

--- a/src/Discord.Net.Rest/API/Exceptions/UnknownEntitieException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/UnknownEntitieException.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Discord.Rest.API
+namespace Discord.Rest.Exceptions
 {
     class UnknownEntitieException
     {

--- a/src/Discord.Net.Rest/API/Exceptions/UnknownEntitieException.cs
+++ b/src/Discord.Net.Rest/API/Exceptions/UnknownEntitieException.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord.Rest.API
+{
+    class UnknownEntitieException
+    {
+    }
+}

--- a/src/Discord.Net.Rest/Discord.Net.Rest.xml
+++ b/src/Discord.Net.Rest/Discord.Net.Rest.xml
@@ -140,47 +140,6 @@
         <member name="M:Discord.API.DiscordRestApiClient.CheckState">
             <exception cref="T:System.InvalidOperationException">Client is not logged in.</exception>
         </member>
-        <member name="M:Discord.Net.Rest.DefaultRestClient.SendAsync(System.String,System.String,System.Collections.Generic.IReadOnlyDictionary{System.String,System.Object},System.Threading.CancellationToken,System.Boolean,System.String)">
-            <exception cref="T:System.InvalidOperationException">Unsupported param type.</exception>
-        </member>
-        <member name="M:Discord.Net.Rest.DefaultRestClientProvider.Create(System.Boolean)">
-            <exception cref="T:System.PlatformNotSupportedException">The default RestClientProvider is not supported on this platform.</exception>
-        </member>
-        <member name="M:Discord.Net.Converters.ImageConverter.ReadJson(Newtonsoft.Json.JsonReader,System.Type,System.Object,Newtonsoft.Json.JsonSerializer)">
-            <exception cref="T:System.InvalidOperationException">Cannot read from image.</exception>
-        </member>
-        <member name="T:Discord.Net.RateLimitInfo">
-            <summary>
-                Represents a REST-Based ratelimit info.
-            </summary>
-        </member>
-        <member name="P:Discord.Net.RateLimitInfo.IsGlobal">
-            <inheritdoc/>
-        </member>
-        <member name="P:Discord.Net.RateLimitInfo.Limit">
-            <inheritdoc/>
-        </member>
-        <member name="P:Discord.Net.RateLimitInfo.Remaining">
-            <inheritdoc/>
-        </member>
-        <member name="P:Discord.Net.RateLimitInfo.RetryAfter">
-            <inheritdoc/>
-        </member>
-        <member name="P:Discord.Net.RateLimitInfo.Reset">
-            <inheritdoc/>
-        </member>
-        <member name="P:Discord.Net.RateLimitInfo.ResetAfter">
-            <inheritdoc/>
-        </member>
-        <member name="P:Discord.Net.RateLimitInfo.Bucket">
-            <inheritdoc/>
-        </member>
-        <member name="P:Discord.Net.RateLimitInfo.Lag">
-            <inheritdoc/>
-        </member>
-        <member name="P:Discord.Net.RateLimitInfo.Endpoint">
-            <inheritdoc/>
-        </member>
         <member name="P:Discord.Rest.BaseDiscordClient.LoginState">
             <summary>
                 Gets the login state of the client.
@@ -5122,6 +5081,47 @@
             <param name="accessToken">The OAuth2 access token for the user, requested with the guilds.join scope.</param>
             <param name="func">The delegate containing the properties to be applied to the user upon being added to the guild.</param>
             <param name="options">The options to be used when sending the request.</param>
+        </member>
+        <member name="M:Discord.Net.Rest.DefaultRestClient.SendAsync(System.String,System.String,System.Collections.Generic.IReadOnlyDictionary{System.String,System.Object},System.Threading.CancellationToken,System.Boolean,System.String)">
+            <exception cref="T:System.InvalidOperationException">Unsupported param type.</exception>
+        </member>
+        <member name="M:Discord.Net.Rest.DefaultRestClientProvider.Create(System.Boolean)">
+            <exception cref="T:System.PlatformNotSupportedException">The default RestClientProvider is not supported on this platform.</exception>
+        </member>
+        <member name="M:Discord.Net.Converters.ImageConverter.ReadJson(Newtonsoft.Json.JsonReader,System.Type,System.Object,Newtonsoft.Json.JsonSerializer)">
+            <exception cref="T:System.InvalidOperationException">Cannot read from image.</exception>
+        </member>
+        <member name="T:Discord.Net.RateLimitInfo">
+            <summary>
+                Represents a REST-Based ratelimit info.
+            </summary>
+        </member>
+        <member name="P:Discord.Net.RateLimitInfo.IsGlobal">
+            <inheritdoc/>
+        </member>
+        <member name="P:Discord.Net.RateLimitInfo.Limit">
+            <inheritdoc/>
+        </member>
+        <member name="P:Discord.Net.RateLimitInfo.Remaining">
+            <inheritdoc/>
+        </member>
+        <member name="P:Discord.Net.RateLimitInfo.RetryAfter">
+            <inheritdoc/>
+        </member>
+        <member name="P:Discord.Net.RateLimitInfo.Reset">
+            <inheritdoc/>
+        </member>
+        <member name="P:Discord.Net.RateLimitInfo.ResetAfter">
+            <inheritdoc/>
+        </member>
+        <member name="P:Discord.Net.RateLimitInfo.Bucket">
+            <inheritdoc/>
+        </member>
+        <member name="P:Discord.Net.RateLimitInfo.Lag">
+            <inheritdoc/>
+        </member>
+        <member name="P:Discord.Net.RateLimitInfo.Endpoint">
+            <inheritdoc/>
         </member>
         <member name="T:Discord.Attachment">
             <inheritdoc cref="T:Discord.IAttachment"/>

--- a/src/Discord.Net.Rest/Utils/DiscordErrorParser.cs
+++ b/src/Discord.Net.Rest/Utils/DiscordErrorParser.cs
@@ -1,4 +1,5 @@
 using Discord.API;
+using Discord.Rest.Exceptions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,7 +12,26 @@ namespace Discord.Rest
     {
         public static void Parse(string outgoingJson, DiscordError error)
         {
-
+            if (error.Code == 0)
+                throw new Exception();
+            if (!int.TryParse((error.Code + "").Substring(0, 2), out var errorPrefix))
+                throw new Exception("Somthing has gone terribly wrong");
+            throw errorPrefix switch
+            {
+                10 => new UnknownEntitieException(), 
+                20 => new GeneralActionException(),
+                30 => new LimitReachedException(),
+                40 => new GeneralRequestException(outgoingJson, error),
+                50 => new PrecondionException(),
+                60 => new MFAException(),
+                80 => new UserSearchException(),
+                90 => new ReactionException(),
+                13 => new APIException(),
+                15 => new StageException(),
+                16 => new ReplyAndThreadException(),
+                17 => new StickerException(),
+                _ => new Exception("not implemented"),
+            };
         }
     }
 }


### PR DESCRIPTION
# Better Errors Pull Request

This branch will add better error handling.

As far as implementation goes, i propose the following:

Add:
`src/Discord.Net.Rest/Utils/DiscordErrorParser.cs`
  -`Parse(string outgoingJson, DiscordError error)`
    - Parses errors returned by the API to create and throw exceptions.

- `src/Discord.Net.Rest/API/Exceptions/UnknownEntitieException.cs` - Throws when an (10XXX) error code is returned.
- `src/Discord.Net.Rest/API/Exceptions/LimitReachedException.cs` - Throws when an (30XXX) error is returned.
- `src/Discord.Net.Rest/API/Exceptions/BadRequestException.cs` - Throws when a (40XXX) error is returned.
- `src/Discord.Net.Rest/API/Exceptions/PreconditionException.cs` - Throws when a (50XXX) error is returned 
- `src/Discord.Net.Rest/API/Exceptions/ReplyAndThreadException.cs` - Throws when a (160XXX) error is returned.
- `src/Discord.Net.Rest/API/Exceptions/tickerException.cs` - throws when a (170XXX) error is returned.
- `src/Discord.Net.Rest/API/Exceptions/GenericJsonExceptions.cs` - See below.
   - `2FAException` - Throws when a (60XXX) error is returned.
   - `UserSearchException` - Throws when a (70XXX) error is returned.
   - `ReactionException` - Throws when a (90XXX) error is returned.
   - `APIException` - throws when a (130XXX) error is returned.
   - `StageException` - throws when a (150XXX) error is returned.

