### PR TITLE
Add channel types in application command options.

### DIFF
--- a/src/Discord.Net.Commands/Discord.Net.Commands.xml
+++ b/src/Discord.Net.Commands/Discord.Net.Commands.xml
@@ -19,7 +19,7 @@
                 <code language="cs">
                 [Command("stats")]
                 [Alias("stat", "info")]
-                public async Task GetStatsAsync(IUser user)
+                public <see langword="async"/> Task GetStatsAsync(IUser user)
                 {
                     // ...pull stats
                 }
@@ -1142,7 +1142,7 @@
                 Specifies if notifications are sent for mentioned users and roles in the <paramref name="message"/>.
                 If <c>null</c>, all mentioned roles and users will be notified.
             </param>
-            <param name="options">The request options for this async request.</param>
+            <param name="options">The request options for this <see langword="async"/> request.</param>
             <param name="messageReference">The message references to be included. Used to reply to specific messages.</param>
             <param name="component">The message components to be included with this message. Used for interactions.</param>
             <param name="stickers">A collection of stickers to send with the file.</param>
@@ -1468,7 +1468,7 @@
         </member>
         <member name="F:Discord.Commands.RunMode.Default">
             <summary>
-            The default behaviour set in <see cref="T:Discord.Commands.CommandServiceConfig"/>.
+            The default behavior set in <see cref="T:Discord.Commands.CommandServiceConfig"/>.
             </summary>
         </member>
         <member name="F:Discord.Commands.RunMode.Sync">

--- a/src/Discord.Net.Core/Discord.Net.Core.xml
+++ b/src/Discord.Net.Core/Discord.Net.Core.xml
@@ -3600,12 +3600,12 @@
         </member>
         <member name="M:Discord.IGuild.GetPublicUpdatesChannelAsync(Discord.CacheMode,Discord.RequestOptions)">
             <summary>
-                Gets the text channel channel where admins and moderators of Community guilds receive notices from Discord.
+                Gets the text channel where admins and moderators of Community guilds receive notices from Discord.
             </summary>
             <param name="mode">The <see cref="T:Discord.CacheMode"/> that determines whether the object should be fetched from cache.</param>
             <param name="options">The options to be used when sending the request.</param>
             <returns>
-                A task that represents the asynchronous get operation. The task result contains the text channel channel where
+                A task that represents the asynchronous get operation. The task result contains the text channel where
                 admins and moderators of Community guilds receive notices from Discord; <see langword="null" /> if none is set.
             </returns>
         </member>
@@ -3835,7 +3835,7 @@
                 Downloads all users for this guild if the current list is incomplete.
             </summary>
             <remarks>
-                This method downloads all users found within this guild throught the Gateway and caches them.
+                This method downloads all users found within this guild through the Gateway and caches them.
             </remarks>
             <returns>
                 A task that represents the asynchronous download operation.
@@ -4564,6 +4564,11 @@
                 Gets or sets if this option is a subcommand or subcommand group type, these nested options will be the parameters.
             </summary>
         </member>
+        <member name="P:Discord.ApplicationCommandOptionProperties.ChannelTypes">
+            <summary>
+                Gets or sets the allowed channel types for this option.
+            </summary>
+        </member>
         <member name="T:Discord.ApplicationCommandOptionChoiceProperties">
             <summary>
                 Represents a choice for a <see cref="T:Discord.IApplicationCommandInteractionDataOption"/>. This class is used when making new commands.
@@ -4741,7 +4746,7 @@
         </member>
         <member name="F:Discord.MessageCommandBuilder.MaxNameLength">
             <summary> 
-                Returns the maximun length a commands name allowed by Discord
+                Returns the maximum length a commands name allowed by Discord
             </summary>
         </member>
         <member name="P:Discord.MessageCommandBuilder.Name">
@@ -4790,7 +4795,7 @@
         </member>
         <member name="F:Discord.UserCommandBuilder.MaxNameLength">
             <summary> 
-                Returns the maximun length a commands name allowed by Discord
+                Returns the maximum length a commands name allowed by Discord
             </summary>
         </member>
         <member name="P:Discord.UserCommandBuilder.Name">
@@ -4951,7 +4956,7 @@
         </member>
         <member name="P:Discord.IApplicationCommandOption.Description">
             <summary>
-                The discription of this command option, 1-100 character description.
+                The description of this command option, 1-100 character description.
             </summary>
         </member>
         <member name="P:Discord.IApplicationCommandOption.Default">
@@ -4972,6 +4977,11 @@
         <member name="P:Discord.IApplicationCommandOption.Options">
             <summary>
                 If the option is a subcommand or subcommand group type, this nested options will be the parameters.
+            </summary>
+        </member>
+        <member name="P:Discord.IApplicationCommandOption.ChannelTypes">
+            <summary>
+            The allowed channel types for this option.
             </summary>
         </member>
         <member name="T:Discord.IApplicationCommandOptionChoice">
@@ -5056,7 +5066,7 @@
             <summary>
                 Gets the original response for this interaction.
             </summary>
-            <param name="options">The request options for this async request.</param>
+            <param name="options">The request options for this <see langword="async"/> request.</param>
             <returns>A <see cref="T:Discord.IUserMessage"/> that represents the initial response.</returns>
         </member>
         <member name="M:Discord.IDiscordInteraction.ModifyOriginalResponseAsync(System.Action{Discord.MessageProperties},Discord.RequestOptions)">
@@ -5064,7 +5074,7 @@
                 Edits original response for this interaction.
             </summary>
             <param name="func">A delegate containing the properties to modify the message with.</param>
-            <param name="options">The request options for this async request.</param>
+            <param name="options">The request options for this <see langword="async"/> request.</param>
             <returns>A <see cref="T:Discord.IUserMessage"/> that represents the initial response.</returns>
         </member>
         <member name="M:Discord.IDiscordInteraction.DeferAsync(System.Boolean,Discord.RequestOptions)">
@@ -5077,7 +5087,7 @@
         </member>
         <member name="T:Discord.IDiscordInteractionData">
             <summary>
-                Represents an interface used to specify classes that they are a vaild dataype of a <see cref="T:Discord.IDiscordInteraction"/> class.
+                Represents an interface used to specify classes that they are a vaild data type of a <see cref="T:Discord.IDiscordInteraction"/> class.
             </summary>
         </member>
         <member name="T:Discord.InteractionResponseType">
@@ -5971,7 +5981,7 @@
         </member>
         <member name="F:Discord.SlashCommandBuilder.MaxNameLength">
             <summary>
-                Returns the maximun length a commands name allowed by Discord
+                Returns the maximum length a commands name allowed by Discord
             </summary>
         </member>
         <member name="F:Discord.SlashCommandBuilder.MaxDescriptionLength">
@@ -6034,7 +6044,7 @@
             <param name="value">The default permission value to set.</param>
             <returns>The current builder.</returns>
         </member>
-        <member name="M:Discord.SlashCommandBuilder.AddOption(System.String,Discord.ApplicationCommandOptionType,System.String,System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Boolean,System.Collections.Generic.List{Discord.SlashCommandOptionBuilder},Discord.ApplicationCommandOptionChoiceProperties[])">
+        <member name="M:Discord.SlashCommandBuilder.AddOption(System.String,Discord.ApplicationCommandOptionType,System.String,System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Boolean,System.Collections.Generic.List{Discord.SlashCommandOptionBuilder},System.Collections.Generic.List{Discord.ChannelType},Discord.ApplicationCommandOptionChoiceProperties[])">
             <summary>
                 Adds an option to the current slash command.
             </summary>
@@ -6045,6 +6055,7 @@
             <param name="isDefault">If this option is the default option.</param>
             <param name="isAutocomplete">If this option is set to autocompleate.</param>
             <param name="options">The options of the option to add.</param>
+            <param name="channelTypes">The allowed channel types for this option.</param>
             <param name="choices">The choices of this option.</param>
             <returns>The current builder.</returns>
         </member>
@@ -6054,7 +6065,7 @@
             </summary>
             <param name="name">The name of the option to add.</param>
             <param name="type">The type of this option.</param>
-            <param name="description">The sescription of this option.</param>
+            <param name="description">The description of this option.</param>
             <returns>The current builder.</returns>
         </member>
         <member name="M:Discord.SlashCommandBuilder.AddOption(Discord.SlashCommandOptionBuilder)">
@@ -6126,13 +6137,18 @@
                 Gets or sets if this option is a subcommand or subcommand group type, these nested options will be the parameters.
             </summary>
         </member>
+        <member name="P:Discord.SlashCommandOptionBuilder.ChannelTypes">
+            <summary>
+                Gets or sets the allowed channel types for this option.
+            </summary>
+        </member>
         <member name="M:Discord.SlashCommandOptionBuilder.Build">
             <summary>
                 Builds the current option.
             </summary>
             <returns>The built version of this option.</returns>
         </member>
-        <member name="M:Discord.SlashCommandOptionBuilder.AddOption(System.String,Discord.ApplicationCommandOptionType,System.String,System.Nullable{System.Boolean},System.Boolean,System.Boolean,System.Collections.Generic.List{Discord.SlashCommandOptionBuilder},Discord.ApplicationCommandOptionChoiceProperties[])">
+        <member name="M:Discord.SlashCommandOptionBuilder.AddOption(System.String,Discord.ApplicationCommandOptionType,System.String,System.Nullable{System.Boolean},System.Boolean,System.Boolean,System.Collections.Generic.List{Discord.SlashCommandOptionBuilder},System.Collections.Generic.List{Discord.ChannelType},Discord.ApplicationCommandOptionChoiceProperties[])">
             <summary>
                 Adds an option to the current slash command.
             </summary>
@@ -6143,6 +6159,7 @@
             <param name="isDefault">If this option is the default option.</param>
             <param name="isAutocomplete">If this option supports autocomplete.</param>
             <param name="options">The options of the option to add.</param>
+            <param name="channelTypes">The allowed channel types for this option.</param>
             <param name="choices">The choices of this option.</param>
             <returns>The current builder.</returns>
         </member>
@@ -6167,6 +6184,13 @@
             </summary>
             <param name="name">The name of the choice.</param>
             <param name="value">The value of the choice.</param>
+            <returns>The current builder.</returns>
+        </member>
+        <member name="M:Discord.SlashCommandOptionBuilder.AddChannelType(Discord.ChannelType)">
+            <summary>
+                Adds a channnel type to the current option.
+            </summary>
+            <param name="channelType">The <see cref="T:Discord.ChannelType"/> to add.</param>
             <returns>The current builder.</returns>
         </member>
         <member name="M:Discord.SlashCommandOptionBuilder.WithName(System.String)">
@@ -6218,7 +6242,7 @@
         </member>
         <member name="P:Discord.SlashCommandProperties.Description">
             <summary>
-               The discription of this command.
+               The description of this command.
             </summary>
         </member>
         <member name="P:Discord.SlashCommandProperties.Options">
@@ -7604,7 +7628,7 @@
                 Gets the clean content for this message.
             </summary>
             <returns>
-                A string that contains the body of the message stripped of mentions, markdown, emojiis and pings; note that this field may be empty if there is an embed.
+                A string that contains the body of the message stripped of mentions, markdown, emojis and pings; note that this field may be empty if there is an embed.
             </returns>
         </member>
         <member name="P:Discord.IMessage.Timestamp">
@@ -8407,7 +8431,7 @@
                     If the <see cref="P:Discord.TimestampTag.Time"/> is null then the default 0 will be used.
                 </para>
             </summary>
-            <returns>A string thats compatable in a discord message, ex: <code>&lt;t:1625944201:f&gt;</code></returns>
+            <returns>A string thats compatible in a discord message, ex: <code>&lt;t:1625944201:f&gt;</code></returns>
         </member>
         <member name="M:Discord.TimestampTag.FromDateTime(System.DateTime,Discord.TimestampTagStyles)">
             <summary>
@@ -8778,7 +8802,7 @@
             <summary> If <c>true</c>, a user may stream video in a voice channel.</summary>
         </member>
         <member name="P:Discord.ChannelPermissions.ManageRoles">
-            <summary> If <c>true</c>, a user may adjust role permissions. This also implictly grants all other permissions.</summary>
+            <summary> If <c>true</c>, a user may adjust role permissions. This also implicitly grants all other permissions.</summary>
         </member>
         <member name="P:Discord.ChannelPermissions.ManageWebhooks">
             <summary> If <c>true</c>, a user may edit the webhooks for this channel.</summary>
@@ -8805,7 +8829,7 @@
             <summary> If <c>true</c>, a user may send messages in threads in this guild.</summary>
         </member>
         <member name="P:Discord.ChannelPermissions.StartEmbeddedActivities">
-            <summary> If <c>true</c>, a user launch application activites in voice channels in this guild.</summary>
+            <summary> If <c>true</c>, a user launch application activities in voice channels in this guild.</summary>
         </member>
         <member name="M:Discord.ChannelPermissions.#ctor(System.UInt64)">
             <summary> Creates a new <see cref="T:Discord.ChannelPermissions"/> with the provided packed value.</summary>
@@ -9222,7 +9246,7 @@
             <summary> If <c>true</c>, a user may send messages in threads in this guild. </summary>
         </member>
         <member name="P:Discord.GuildPermissions.StartEmbeddedActivities">
-            <summary> If <c>true</c>, a user launch application activites in voice channels in this guild. </summary>
+            <summary> If <c>true</c>, a user launch application activities in voice channels in this guild. </summary>
         </member>
         <member name="M:Discord.GuildPermissions.#ctor(System.UInt64)">
             <summary> Creates a new <see cref="T:Discord.GuildPermissions"/> with the provided packed value. </summary>
@@ -9396,7 +9420,7 @@
             <summary> If <c>true</c>, a user may send messages in threads in this guild. </summary>
         </member>
         <member name="P:Discord.OverwritePermissions.StartEmbeddedActivities">
-            <summary> If <c>true</c>, a user launch application activites in voice channels in this guild. </summary>
+            <summary> If <c>true</c>, a user launch application activities in voice channels in this guild. </summary>
         </member>
         <member name="M:Discord.OverwritePermissions.#ctor(System.UInt64,System.UInt64)">
             <summary> Creates a new OverwritePermissions with the provided allow and deny packed values. </summary>
@@ -9892,7 +9916,7 @@
                 Deletes the current sticker.
             </summary>
             <remakrs>
-                The bot neeeds the MANAGE_EMOJIS_AND_STICKERS permission inside the guild in order to delete stickers.
+                The bot needs the MANAGE_EMOJIS_AND_STICKERS permission inside the guild in order to delete stickers.
             </remakrs>
             <param name="options">The options to be used when sending the request.</param>
             <returns>
@@ -11189,7 +11213,7 @@
                 Add multiple reactions to a message.
             </summary>
             <remarks>
-                This method does not bulk add reactions! It will send a request for each reaction inculded.
+                This method does not bulk add reactions! It will send a request for each reaction included.
             </remarks>
             <example>
             <code language="cs">
@@ -11234,7 +11258,7 @@
             <summary>
                 Sends an inline reply that references a message.
             </summary>
-            <param name="msg">The message that is being replyed on.</param>
+            <param name="msg">The message that is being replied on.</param>
             <param name="text">The message to be sent.</param>
             <param name="isTTS">Determines whether the message should be read aloud by Discord or not.</param>
             <param name="embed">The <see cref="F:Discord.EmbedType.Rich"/> <see cref="T:Discord.Embed"/> to be sent.</param>
@@ -11405,7 +11429,7 @@
             <summary> Returns a markdown-formatted string with underline formatting. </summary>
         </member>
         <member name="M:Discord.Format.Strikethrough(System.String)">
-            <summary> Returns a markdown-formatted string with strikethrough formatting. </summary>
+            <summary> Returns a markdown-formatted string with strike-through formatting. </summary>
         </member>
         <member name="M:Discord.Format.Spoiler(System.String)">
             <summary> Returns a string with spoiler formatting. </summary>
@@ -12242,10 +12266,10 @@
         </member>
         <member name="P:Discord.RequestOptions.Timeout">
             <summary>
-                Gets or sets the maximum time to wait for for this request to complete.
+                Gets or sets the maximum time to wait for this request to complete.
             </summary>
             <remarks>
-                Gets or set the max time, in milliseconds, to wait for for this request to complete. If 
+                Gets or set the max time, in milliseconds, to wait for this request to complete. If 
                 <c>null</c>, a request will not time out. If a rate limit has been triggered for this request's bucket
                 and will not be unpaused in time, this request will fail immediately.
             </remarks>

--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
@@ -81,6 +81,9 @@ namespace Discord
         /// </summary>
         public List<ApplicationCommandOptionProperties> Options { get; set; }
 
-        
+        /// <summary>
+        ///     Gets or sets the allowed channel types for this option.
+        /// </summary>
+        public List<ChannelType> ChannelTypes { get; set; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandOption.cs
@@ -45,5 +45,10 @@ namespace Discord
         ///     If the option is a subcommand or subcommand group type, this nested options will be the parameters.
         /// </summary>
         IReadOnlyCollection<IApplicationCommandOption>? Options { get; }
+
+        /// <summary>
+        /// The allowed channel types for this option.
+        /// </summary>
+        IReadOnlyCollection<ChannelType>? ChannelTypes { get; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandOption.cs
@@ -47,7 +47,7 @@ namespace Discord
         IReadOnlyCollection<IApplicationCommandOption>? Options { get; }
 
         /// <summary>
-        /// The allowed channel types for this option.
+        ///     The allowed channel types for this option.
         /// </summary>
         IReadOnlyCollection<ChannelType>? ChannelTypes { get; }
     }

--- a/src/Discord.Net.Core/Entities/Interactions/Slash Commands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Slash Commands/SlashCommandBuilder.cs
@@ -165,10 +165,12 @@ namespace Discord
         /// <param name="isDefault">If this option is the default option.</param>
         /// <param name="isAutocomplete">If this option is set to autocompleate.</param>
         /// <param name="options">The options of the option to add.</param>
+        /// <param name="channelTypes">The allowed channel types for this option.</param>
         /// <param name="choices">The choices of this option.</param>
         /// <returns>The current builder.</returns>
         public SlashCommandBuilder AddOption(string name, ApplicationCommandOptionType type,
-           string description, bool? required = null, bool? isDefault = null, bool isAutocomplete = false, List<SlashCommandOptionBuilder> options = null, params ApplicationCommandOptionChoiceProperties[] choices)
+           string description, bool? required = null, bool? isDefault = null, bool isAutocomplete = false, List<SlashCommandOptionBuilder> options = null,
+           List<ChannelType> channelTypes = null, params ApplicationCommandOptionChoiceProperties[] choices)
         {
             // Make sure the name matches the requirements from discord
             Preconditions.NotNullOrEmpty(name, nameof(name));
@@ -202,7 +204,8 @@ namespace Discord
                 Options = options,
                 Type = type,
                 Autocomplete = isAutocomplete,
-                Choices = choices != null ? new List<ApplicationCommandOptionChoiceProperties>(choices) : null
+                Choices = choices != null ? new List<ApplicationCommandOptionChoiceProperties>(choices) : null,
+                ChannelTypes = channelTypes,
             };
 
             return AddOption(option);
@@ -348,6 +351,11 @@ namespace Discord
         public List<SlashCommandOptionBuilder> Options { get; set; }
 
         /// <summary>
+        ///     Gets or sets the allowed channel types for this option.
+        /// </summary>
+        public List<ChannelType> ChannelTypes { get; set; }
+
+        /// <summary>
         ///     Builds the current option.
         /// </summary>
         /// <returns>The built version of this option.</returns>
@@ -370,7 +378,8 @@ namespace Discord
                 Type = Type,
                 Options = Options?.Count > 0 ? new List<ApplicationCommandOptionProperties>(Options.Select(x => x.Build())) : null,
                 Choices = Choices,
-                Autocomplete = Autocomplete
+                Autocomplete = Autocomplete,
+                ChannelTypes = ChannelTypes
             };
         }
 
@@ -384,10 +393,12 @@ namespace Discord
         /// <param name="isDefault">If this option is the default option.</param>
         /// <param name="isAutocomplete">If this option supports autocomplete.</param>
         /// <param name="options">The options of the option to add.</param>
+        /// <param name="channelTypes">The allowed channel types for this option.</param>
         /// <param name="choices">The choices of this option.</param>
         /// <returns>The current builder.</returns>
         public SlashCommandOptionBuilder AddOption(string name, ApplicationCommandOptionType type,
-           string description, bool? required = null, bool isDefault = false, bool isAutocomplete = false, List<SlashCommandOptionBuilder> options = null, params ApplicationCommandOptionChoiceProperties[] choices)
+           string description, bool? required = null, bool isDefault = false, bool isAutocomplete = false, List<SlashCommandOptionBuilder> options = null,
+           List<ChannelType> channelTypes = null, params ApplicationCommandOptionChoiceProperties[] choices)
         {
             // Make sure the name matches the requirements from discord
             Preconditions.NotNullOrEmpty(name, nameof(name));
@@ -422,6 +433,7 @@ namespace Discord
                 Options = options,
                 Type = type,
                 Choices = choices != null ? new List<ApplicationCommandOptionChoiceProperties>(choices) : null,
+                ChannelTypes = channelTypes,
             };
 
             return AddOption(option);
@@ -506,6 +518,21 @@ namespace Discord
                 Name = name,
                 Value = value
             });
+
+            return this;
+        }
+
+        /// <summary>
+        ///     Adds a channnel type to the current option.
+        /// </summary>
+        /// <param name="channelType">The <see cref="ChannelType"/> to add.</param>
+        /// <returns>The current builder.</returns>
+        public SlashCommandOptionBuilder AddChannelType(ChannelType channelType)
+        {
+            if (ChannelTypes == null)
+                ChannelTypes = new List<ChannelType>();
+
+            ChannelTypes.Add(channelType);
 
             return this;
         }

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandOption.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandOption.cs
@@ -33,6 +33,9 @@ namespace Discord.API
         [JsonProperty("autocomplete")]
         public Optional<bool> Autocomplete { get; set; }
 
+        [JsonProperty("channel_types")]
+        public Optional<ChannelType[]> ChannelTypes { get; set; }
+
         public ApplicationCommandOption() { }
 
         public ApplicationCommandOption(IApplicationCommandOption cmd)
@@ -44,6 +47,8 @@ namespace Discord.API
             }).ToArray();
 
             Options = cmd.Options.Select(x => new ApplicationCommandOption(x)).ToArray();
+
+            ChannelTypes = cmd.ChannelTypes.ToArray();
 
             Required = cmd.Required.HasValue
                 ? cmd.Required.Value
@@ -77,6 +82,10 @@ namespace Discord.API
             Default = option.Default.HasValue
                 ? option.Default.Value
                 : Optional<bool>.Unspecified;
+
+            ChannelTypes = option.ChannelTypes != null
+                ? option.ChannelTypes.ToArray()
+                : Optional<ChannelType[]>.Unspecified;
 
             Name = option.Name;
             Type = option.Type;

--- a/src/Discord.Net.Rest/Discord.Net.Rest.xml
+++ b/src/Discord.Net.Rest/Discord.Net.Rest.xml
@@ -2637,7 +2637,7 @@
         </member>
         <member name="T:Discord.Rest.RestThreadChannel">
             <summary>
-                Represents a thread channel recieved over REST.
+                Represents a thread channel received over REST.
             </summary>
         </member>
         <member name="P:Discord.Rest.RestThreadChannel.Joined">
@@ -2673,7 +2673,7 @@
             <param name="userId">The id of the user to fetch.</param>
             <param name="options">The options to be used when sending the request.</param>
             <returns>
-                A task representing the asyncronous get operation. The task returns a
+                A task representing the asynchronous get operation. The task returns a
                 <see cref="T:Discord.Rest.RestThreadUser"/> if found, otherwise <see langword="null"/>.
             </returns>
         </member>
@@ -2683,7 +2683,7 @@
             </summary>
             <param name="options">The options to be used when sending the request.</param>
             <returns>
-                A task representing the asyncronous get operation. The task returns a
+                A task representing the asynchronous get operation. The task returns a
                 <see cref="T:System.Collections.Generic.IReadOnlyCollection`1"/> of <see cref="T:Discord.Rest.RestThreadUser"/>'s.
             </returns>
         </member>
@@ -3298,7 +3298,7 @@
             <param name="options">The options to be used when sending the request.</param>
             <returns>
                 A task that represents the asynchronous get operation. The task result contains the text channel
-                where guild notices such as welcome messages and boost events are poste; <see langword="null"/> if none is found.
+                where guild notices such as welcome messages and boost events are post; <see langword="null"/> if none is found.
             </returns>
         </member>
         <member name="M:Discord.Rest.RestGuild.GetRulesChannelAsync(Discord.RequestOptions)">
@@ -3313,11 +3313,11 @@
         </member>
         <member name="M:Discord.Rest.RestGuild.GetPublicUpdatesChannelAsync(Discord.RequestOptions)">
             <summary>
-                Gets the text channel channel where admins and moderators of Community guilds receive notices from Discord.
+                Gets the text channel where admins and moderators of Community guilds receive notices from Discord.
             </summary>
             <param name="options">The options to be used when sending the request.</param>
             <returns>
-                A task that represents the asynchronous get operation. The task result contains the text channel channel where
+                A task that represents the asynchronous get operation. The task result contains the text channel where
                 admins and moderators of Community guilds receive notices from Discord; <see langword="null"/> if none is set.
             </returns>
         </member>
@@ -3562,7 +3562,7 @@
         </member>
         <member name="M:Discord.Rest.RestGuild.GetApplicationCommandsAsync(Discord.RequestOptions)">
             <summary>
-                Gets this guilds slash commands commands
+                Gets this guilds slash commands
             </summary>
             <param name="options">The options to be used when sending the request.</param>
             <returns>
@@ -4029,6 +4029,11 @@
                 A collection of <see cref="T:Discord.Rest.RestApplicationCommandOption"/>'s for this command.
             </summary>
         </member>
+        <member name="P:Discord.Rest.RestApplicationCommandOption.ChannelTypes">
+            <summary>
+            The allowed channel types for this option.
+            </summary>
+        </member>
         <member name="T:Discord.Rest.RestGlobalCommand">
             <summary>
                 Represents a Rest-based global application command.
@@ -4191,7 +4196,7 @@
                 Gets the guild that this custom sticker is in.
             </summary>
             <remarks>
-                <b>Note</b>: This property can be <see langword="null"/> if the sticker wasnt fetched from a guild.
+                <b>Note</b>: This property can be <see langword="null"/> if the sticker wasn't fetched from a guild.
             </remarks>
         </member>
         <member name="M:Discord.Rest.CustomSticker.DeleteAsync(Discord.RequestOptions)">
@@ -4221,7 +4226,7 @@
         </member>
         <member name="M:Discord.Rest.RestFollowupMessage.DeleteAsync">
             <summary>
-                Deletes this object and all of it's childern.
+                Deletes this object and all of it's children.
             </summary>
             <returns>A task that represents the asynchronous delete operation.</returns>
         </member>
@@ -4245,7 +4250,7 @@
                 A task that represents the asynchronous modification operation.
             </returns>
             <exception cref="T:System.InvalidOperationException">The token used to modify/delete this message expired.</exception>
-            /// <exception cref="T:Discord.Net.HttpException">Somthing went wrong during the request.</exception>
+            /// <exception cref="T:Discord.Net.HttpException">Something went wrong during the request.</exception>
         </member>
         <member name="T:Discord.Rest.RestInteractionMessage">
             <summary>
@@ -4254,7 +4259,7 @@
         </member>
         <member name="M:Discord.Rest.RestInteractionMessage.DeleteAsync">
             <summary>
-                Deletes this object and all of it's childern.
+                Deletes this object and all of it's children.
             </summary>
             <returns>A task that represents the asynchronous delete operation.</returns>
         </member>
@@ -4278,7 +4283,7 @@
                 A task that represents the asynchronous modification operation.
             </returns>
             <exception cref="T:System.InvalidOperationException">The token used to modify/delete this message expired.</exception>
-            /// <exception cref="T:Discord.Net.HttpException">Somthing went wrong during the request.</exception>
+            /// <exception cref="T:Discord.Net.HttpException">Something went wrong during the request.</exception>
         </member>
         <member name="T:Discord.Rest.RestMessage">
             <summary>

--- a/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommandOption.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommandOption.cs
@@ -40,9 +40,9 @@ namespace Discord.Rest
         public IReadOnlyCollection<RestApplicationCommandOption> Options { get; private set; }
 
         /// <summary>
-        /// The allowed channel types for this option.
+        ///     The allowed channel types for this option.
         /// </summary>
-        public IReadOnlyCollection<ChannelType>? ChannelTypes { get; private set; }
+        public IReadOnlyCollection<ChannelType> ChannelTypes { get; private set; }
 
         internal RestApplicationCommandOption() { }
 

--- a/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommandOption.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommandOption.cs
@@ -39,6 +39,11 @@ namespace Discord.Rest
         /// </summary>
         public IReadOnlyCollection<RestApplicationCommandOption> Options { get; private set; }
 
+        /// <summary>
+        /// The allowed channel types for this option.
+        /// </summary>
+        public IReadOnlyCollection<ChannelType>? ChannelTypes { get; private set; }
+
         internal RestApplicationCommandOption() { }
 
         internal static RestApplicationCommandOption Create(Model model)
@@ -66,6 +71,10 @@ namespace Discord.Rest
 
             Choices = model.Choices.IsSpecified
                 ? model.Choices.Value.Select(x => new RestApplicationCommandChoice(x)).ToImmutableArray()
+                : null;
+
+            ChannelTypes = model.ChannelTypes.IsSpecified
+                ? model.ChannelTypes.Value.ToImmutableArray()
                 : null;
         }
         #endregion

--- a/src/Discord.Net.WebSocket/Discord.Net.WebSocket.xml
+++ b/src/Discord.Net.WebSocket/Discord.Net.WebSocket.xml
@@ -709,7 +709,7 @@
         </member>
         <member name="E:Discord.WebSocket.BaseSocketClient.InteractionCreated">
             <summary>
-                Fired when an Interaction is created. This event covers all types of interactions including but not limited to: buttons, select menus, slash commands.
+                Fired when an Interaction is created. This event covers all types of interactions including but not limited to: buttons, select menus, slash commands, autocompletes.
             </summary>
             <remarks>
                 <para>
@@ -746,11 +746,11 @@
                 Fired when a message command is used and its interaction is received.
             </summary>
         </member>
-		<member name="E:Discord.WebSocket.BaseSocketClient.AutocompleteExecuted">
-			<summary>
-				Fired when an autocomplete is used and its interaction is received.
-			</summary>
-		</member>
+        <member name="E:Discord.WebSocket.BaseSocketClient.AutocompleteExecuted">
+            <summary>
+                Fired when an autocomplete is used and its interaction is received.
+            </summary>
+        </member>
         <member name="E:Discord.WebSocket.BaseSocketClient.ApplicationCommandCreated">
              <summary>
                  Fired when a guild application command is created.
@@ -1009,7 +1009,7 @@
             </summary>
         </member>
         <member name="P:Discord.WebSocket.DiscordSocketClient.ShardId">
-            <summary> Gets the shard of of this client. </summary>
+            <summary> Gets the shard of this client. </summary>
         </member>
         <member name="P:Discord.WebSocket.DiscordSocketClient.ConnectionState">
             <summary> Gets the current connection state of this client. </summary>
@@ -1373,7 +1373,7 @@
             <remarks>
                 <para>
                     By default, the Discord gateway will only send offline members if a guild has less than a certain number
-                    of members (determined by <see cref="P:Discord.WebSocket.DiscordSocketConfig.LargeThreshold"/> in this library). This behaviour is why
+                    of members (determined by <see cref="P:Discord.WebSocket.DiscordSocketConfig.LargeThreshold"/> in this library). This behavior is why
                     sometimes a user may be missing from the WebSocket cache for collections such as
                     <see cref="P:Discord.WebSocket.SocketGuild.Users"/>.
                 </para>
@@ -2265,7 +2265,7 @@
         </member>
         <member name="T:Discord.WebSocket.SocketStageChannel">
             <summary>
-                Represents a stage channel recieved over the gateway.
+                Represents a stage channel received over the gateway.
             </summary>
         </member>
         <member name="P:Discord.WebSocket.SocketStageChannel.Topic">
@@ -3869,7 +3869,7 @@
         </member>
         <member name="P:Discord.WebSocket.SocketMessageCommandData.Message">
             <summary>
-                Gets the messagte associated with this message command.
+                Gets the message associated with this message command.
             </summary>
         </member>
         <member name="P:Discord.WebSocket.SocketMessageCommandData.Options">
@@ -3927,7 +3927,7 @@
                 Updates the message which this component resides in with the type <see cref="F:Discord.InteractionResponseType.UpdateMessage"/>
             </summary>
             <param name="func">A delegate containing the properties to modify the message with.</param>
-            <param name="options">The request options for this async request.</param>
+            <param name="options">The request options for this <see langword="async"/> request.</param>
             <returns>A task that represents the asynchronous operation of updating the message.</returns>
         </member>
         <member name="M:Discord.WebSocket.SocketMessageComponent.FollowupAsync(System.String,Discord.Embed[],System.Boolean,System.Boolean,Discord.AllowedMentions,Discord.RequestOptions,Discord.MessageComponent,Discord.Embed)">
@@ -3944,7 +3944,7 @@
                 Defers an interaction and responds with type 5 (<see cref="F:Discord.InteractionResponseType.DeferredChannelMessageWithSource"/>)
             </summary>
             <param name="ephemeral"><see langword="true"/> to send this message ephemerally, otherwise <see langword="false"/>.</param>
-            <param name="options">The request options for this async request.</param>
+            <param name="options">The request options for this <see langword="async"/> request.</param>
             <returns>
                 A task that represents the asynchronous operation of acknowledging the interaction.
             </returns>
@@ -4056,7 +4056,7 @@
         </member>
         <member name="P:Discord.WebSocket.SocketAutocompleteInteractionData.Current">
             <summary>
-                Gets the current autocomplete option that is activly being filled out.
+                Gets the current autocomplete option that is actively being filled out.
             </summary>
         </member>
         <member name="P:Discord.WebSocket.SocketAutocompleteInteractionData.Options">
@@ -4081,7 +4081,7 @@
         </member>
         <member name="T:Discord.WebSocket.SocketSlashCommandDataOption">
             <summary>
-                Represents a Websocket-based <see cref="T:Discord.IApplicationCommandInteractionDataOption"/> recieved by the gateway
+                Represents a Websocket-based <see cref="T:Discord.IApplicationCommandInteractionDataOption"/> received by the gateway
             </summary>
         </member>
         <member name="P:Discord.WebSocket.SocketSlashCommandDataOption.Name">
@@ -4189,6 +4189,11 @@
                 If the option is a subcommand or subcommand group type, this nested options will be the parameters.
             </summary>
         </member>
+        <member name="P:Discord.WebSocket.SocketApplicationCommandOption.ChannelTypes">
+            <summary>
+            The allowed channel types for this option.
+            </summary>
+        </member>
         <member name="T:Discord.WebSocket.SocketCommandBase">
             <summary>
                 Base class for User, Message, and Slash command interactions.
@@ -4249,7 +4254,7 @@
         </member>
         <member name="T:Discord.WebSocket.SocketInteraction">
             <summary>
-                Represents an Interaction recieved over the gateway.
+                Represents an Interaction received over the gateway.
             </summary>
         </member>
         <member name="P:Discord.WebSocket.SocketInteraction.Channel">
@@ -4920,7 +4925,7 @@
             <remarks>
                 <note>
                     This may return <see langword="null"/> in the WebSocket implementation due to incomplete user collection in
-                    large guilds, or the bot doesnt have the MANAGE_EMOJIS_AND_STICKERS permission.
+                    large guilds, or the bot doesn't have the MANAGE_EMOJIS_AND_STICKERS permission.
                 </note>
             </remarks>
         </member>

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommandOption.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommandOption.cs
@@ -38,6 +38,11 @@ namespace Discord.WebSocket
         /// </summary>
         public IReadOnlyCollection<SocketApplicationCommandOption> Options { get; private set; }
 
+        /// <summary>
+        /// The allowed channel types for this option.
+        /// </summary>
+        public IReadOnlyCollection<ChannelType> ChannelTypes { get; private set; }
+
         internal SocketApplicationCommandOption() { }
         internal static SocketApplicationCommandOption Create(Model model)
         {
@@ -67,6 +72,10 @@ namespace Discord.WebSocket
             Options = model.Options.IsSpecified
                 ? model.Options.Value.Select(x => SocketApplicationCommandOption.Create(x)).ToImmutableArray()
                 : new ImmutableArray<SocketApplicationCommandOption>();
+
+            ChannelTypes = model.ChannelTypes.IsSpecified
+                ? model.ChannelTypes.Value.ToImmutableArray()
+                : new ImmutableArray<ChannelType>();
         }
 
         IReadOnlyCollection<IApplicationCommandOptionChoice> IApplicationCommandOption.Choices => Choices;

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommandOption.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommandOption.cs
@@ -39,7 +39,7 @@ namespace Discord.WebSocket
         public IReadOnlyCollection<SocketApplicationCommandOption> Options { get; private set; }
 
         /// <summary>
-        /// The allowed channel types for this option.
+        ///     The allowed channel types for this option.
         /// </summary>
         public IReadOnlyCollection<ChannelType> ChannelTypes { get; private set; }
 


### PR DESCRIPTION
This adds support for specifying channel types in ApplicationCommandOptions (see https://github.com/Discord-Net-Labs/Discord.Net-Labs/issues/209)
