### PR TITLE
General cleanup

### DIFF
--- a/src/Discord.Net.Core/Entities/Channels/IStageChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IStageChannel.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Discord
@@ -28,7 +25,7 @@ namespace Discord
         StagePrivacyLevel? PrivacyLevel { get; }
 
         /// <summary>
-        ///     <see langword="true"/> if stage discovery is disabled, otherwise <see langword="false"/>. 
+        ///     <see langword="true"/> if stage discovery is disabled, otherwise <see langword="false"/>.
         /// </summary>
         bool? DiscoverableDisabled { get; }
 

--- a/src/Discord.Net.Core/Entities/Channels/IThreadChannel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/IThreadChannel.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Discord
@@ -9,7 +6,7 @@ namespace Discord
     /// <summary>
     ///     Represents a thread channel inside of a guild.
     /// </summary>
-    public interface IThreadChannel : ITextChannel, IGuildChannel
+    public interface IThreadChannel : ITextChannel
     {
         /// <summary>
         ///     Gets the type of the current thread channel.
@@ -56,7 +53,7 @@ namespace Discord
         /// </summary>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
-        ///     A task that represents the asynchronous join operation. 
+        ///     A task that represents the asynchronous join operation.
         /// </returns>
         Task JoinAsync(RequestOptions options = null);
 
@@ -65,7 +62,7 @@ namespace Discord
         /// </summary>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
-        ///     A task that represents the asynchronous leave operation. 
+        ///     A task that represents the asynchronous leave operation.
         /// </returns>
         Task LeaveAsync(RequestOptions options = null);
 
@@ -75,7 +72,7 @@ namespace Discord
         /// <param name="user">The <see cref="IGuildUser"/> to add.</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
-        ///     A task that represents the asynchronous operation of adding a member to a thread. 
+        ///     A task that represents the asynchronous operation of adding a member to a thread.
         /// </returns>
         Task AddUserAsync(IGuildUser user, RequestOptions options = null);
 
@@ -85,7 +82,7 @@ namespace Discord
         /// <param name="user">The <see cref="IGuildUser"/> to remove from this thread.</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
-        ///     A task that represents the asynchronous operation of removing a user from this thread. 
+        ///     A task that represents the asynchronous operation of removing a user from this thread.
         /// </returns>
         Task RemoveUserAsync(IGuildUser user, RequestOptions options = null);
     }

--- a/src/Discord.Net.Core/Entities/Channels/StageInstanceProperties.cs
+++ b/src/Discord.Net.Core/Entities/Channels/StageInstanceProperties.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>

--- a/src/Discord.Net.Core/Entities/Channels/StagePrivacyLevel.cs
+++ b/src/Discord.Net.Core/Entities/Channels/StagePrivacyLevel.cs
@@ -1,14 +1,17 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
+    /// <summary>
+    ///     Specifies the privacy levels of a Stage instance.
+    /// </summary>
     public enum StagePrivacyLevel
     {
+        /// <summary>
+        ///     The Stage instance is visible publicly, such as on Stage Discovery.
+        /// </summary>
         Public = 1,
-        GuildOnly = 2,
+        /// <summary>
+        ///     The Stage instance is visible to only guild members.
+        /// </summary>
+        GuildOnly = 2
     }
 }

--- a/src/Discord.Net.Core/Entities/Channels/ThreadArchiveDuration.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ThreadArchiveDuration.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>
@@ -24,7 +18,7 @@ namespace Discord
         /// <summary>
         ///     Three days (4320 minutes).
         ///     <remarks>
-        ///         This option is explicity avaliable to nitro users.
+        ///         This option is explicitly available to nitro users.
         ///     </remarks>
         /// </summary>
         ThreeDays = 4320,
@@ -32,9 +26,9 @@ namespace Discord
         /// <summary>
         ///     One week (10080 minutes).
         ///     <remarks>
-        ///         This option is explicity avaliable to nitro users.
+        ///         This option is explicitly available to nitro users.
         ///     </remarks>
         /// </summary>
-        OneWeek = 10080,
+        OneWeek = 10080
     }
 }

--- a/src/Discord.Net.Core/Entities/Channels/ThreadType.cs
+++ b/src/Discord.Net.Core/Entities/Channels/ThreadType.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>
@@ -24,6 +18,6 @@ namespace Discord
         /// <summary>
         ///     Represents a temporary sub-channel within a GUILD_TEXT channel that is only viewable by those invited and those with the MANAGE_THREADS permission
         /// </summary>
-        PrivateThread = 12,
+        PrivateThread = 12
     }
 }

--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
@@ -21,7 +21,7 @@ namespace Discord
             set
             {
                 if (value == null)
-                    throw new ArgumentNullException(nameof(value));
+                    throw new ArgumentNullException(nameof(value), $"{nameof(Name)} cannot be null.");
 
                 if (value.Length > 32)
                     throw new ArgumentOutOfRangeException(nameof(value), "Name length must be less than or equal to 32.");

--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace Discord
 {
@@ -24,13 +21,13 @@ namespace Discord
             set
             {
                 if (value == null)
-                    throw new ArgumentNullException($"{nameof(Name)} cannot be null!");
+                    throw new ArgumentNullException(nameof(value));
 
                 if (value.Length > 32)
-                    throw new ArgumentException($"{nameof(Name)} length must be less than or equal to 32");
+                    throw new ArgumentOutOfRangeException(nameof(value), "Name length must be less than or equal to 32.");
 
                 if (!Regex.IsMatch(value, @"^[\w-]{1,32}$"))
-                    throw new ArgumentException($"{nameof(Name)} must match the regex ^[\\w-]{{1,32}}$");
+                    throw new FormatException($"{nameof(value)} must match the regex ^[\\w-]{{1,32}}$");
 
                 _name = value;
             }
@@ -42,14 +39,12 @@ namespace Discord
         public string Description
         {
             get => _description;
-            set
+            set => _description = value?.Length switch
             {
-                if (value?.Length > 100)
-                    throw new ArgumentException("Description length must be less than or equal to 100");
-                if (value?.Length < 1)
-                    throw new ArgumentException("Description length must at least 1 character in length");
-                _description = value;
-            }
+                > 100 => throw new ArgumentOutOfRangeException(nameof(value), "Description length must be less than or equal to 100."),
+                0 => throw new ArgumentOutOfRangeException(nameof(value), "Description length must be at least 1."),
+                _ => value
+            };
         }
 
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOptionChoice.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOptionChoice.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord
 {
@@ -19,14 +15,12 @@ namespace Discord
         public string Name
         {
             get => _name;
-            set
+            set => _name = value?.Length switch
             {
-                if(value?.Length > 100)
-                    throw new ArgumentException("Name length must be less than or equal to 100");
-                if (value?.Length < 1)
-                    throw new ArgumentException("Name length must at least 1 character in length");
-                _name = value;
-            }
+                > 100 => throw new ArgumentOutOfRangeException(nameof(value), "Name length must be less than or equal to 100."),
+                0 => throw new ArgumentOutOfRangeException(nameof(value), "Name length must at least 1."),
+                _ => value
+            };
         }
 
         /// <summary>
@@ -40,11 +34,8 @@ namespace Discord
             get => _value;
             set
             {
-                if(value != null)
-                {
-                    if(!(value is int) && !(value is string))
-                        throw new ArgumentException("The value of a choice must be a string or int!");
-                }
+                if (value != null && value is not int && value is not string)
+                    throw new ArgumentException("The value of a choice must be a string or int!");
                 _value = value;
             }
         }

--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOptionType.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOptionType.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>
@@ -37,7 +31,7 @@ namespace Discord
         Boolean = 5,
 
         /// <summary>
-        ///     A <see cref="IGuildUser"/>.
+        ///     A <see cref="IUser"/>.
         /// </summary>
         User = 6,
 
@@ -55,7 +49,7 @@ namespace Discord
         ///     A <see cref="IUser"/> or <see cref="IRole"/>.
         /// </summary>
         Mentionable = 9,
-        
+
         /// <summary>
         ///     A <see cref="double"/>.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandProperties.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandProperties.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>

--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandTypes.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandTypes.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>

--- a/src/Discord.Net.Core/Entities/Interactions/AutocompleteOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/AutocompleteOption.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>

--- a/src/Discord.Net.Core/Entities/Interactions/AutocompleteResult.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/AutocompleteResult.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord
 {
@@ -11,8 +7,8 @@ namespace Discord
     /// </summary>
     public class AutocompleteResult
     {
-        private object _value { get; set; }
-        private string _name { get; set; }
+        private object _value;
+        private string _name;
 
         /// <summary>
         ///     Gets or sets the name of the result.
@@ -28,12 +24,13 @@ namespace Discord
             set
             {
                 if (value == null)
-                    throw new ArgumentException("Name cannot be null!");
-                if (value.Length > 100)
-                    throw new ArgumentException("Name length must be less than or equal to 100 characters in length!");
-                if (value.Length < 1)
-                    throw new ArgumentException("Name length must at least 1 character in length!");
-                _name = value;
+                    throw new ArgumentNullException(nameof(value));
+                _name = value.Length switch
+                {
+                    > 100 => throw new ArgumentOutOfRangeException(nameof(value), "Name length must be less than or equal to 100."),
+                    0 => throw new ArgumentOutOfRangeException(nameof(value), "Name length must be at least 1."),
+                    _ => value
+                };
             }
         }
 
@@ -48,20 +45,15 @@ namespace Discord
         public object Value
         {
             get => _value;
-            set
+            set => _value = value switch
             {
-                if (value == null)
-                    throw new ArgumentNullException("Value cannot be null");
-
-                _value = value switch
-                {
-                    string str => str,
-                    int integer => integer,
-                    long lng => lng,
-                    double number => number,
-                    _ => throw new ArgumentException($"Type {value.GetType().Name} cannot be set as a value! Only string, int, and double allowed!"),
-                };
-            }
+                string str => str,
+                int integer => integer,
+                long lng => lng,
+                double number => number,
+                null => throw new ArgumentNullException(nameof(value)),
+                _ => throw new ArgumentException($"Type {value.GetType().Name} cannot be set as a value! Only string, int, and double allowed!")
+            };
         }
 
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Interactions/AutocompleteResult.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/AutocompleteResult.cs
@@ -24,7 +24,7 @@ namespace Discord
             set
             {
                 if (value == null)
-                    throw new ArgumentNullException(nameof(value));
+                    throw new ArgumentNullException(nameof(value), $"{nameof(Name)} cannot be null.");
                 _name = value.Length switch
                 {
                     > 100 => throw new ArgumentOutOfRangeException(nameof(value), "Name length must be less than or equal to 100."),
@@ -51,7 +51,7 @@ namespace Discord
                 int integer => integer,
                 long lng => lng,
                 double number => number,
-                null => throw new ArgumentNullException(nameof(value)),
+                null => throw new ArgumentNullException(nameof(value), $"{nameof(Value)} cannot be null."),
                 _ => throw new ArgumentException($"Type {value.GetType().Name} cannot be set as a value! Only string, int, and double allowed!")
             };
         }

--- a/src/Discord.Net.Core/Entities/Interactions/Context Menus/MessageCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Context Menus/MessageCommandBuilder.cs
@@ -48,7 +48,6 @@ namespace Discord
             };
 
             return props;
-
         }
 
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Interactions/Context Menus/MessageCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Context Menus/MessageCommandBuilder.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>
@@ -12,7 +5,7 @@ namespace Discord
     /// </summary>
     public class MessageCommandBuilder
     {
-        /// <summary> 
+        /// <summary>
         ///     Returns the maximum length a commands name allowed by Discord
         /// </summary>
         public const int MaxNameLength = 32;
@@ -22,10 +15,7 @@ namespace Discord
         /// </summary>
         public string Name
         {
-            get
-            {
-                return _name;
-            }
+            get => _name;
             set
             {
                 Preconditions.NotNullOrEmpty(value, nameof(Name));
@@ -41,7 +31,7 @@ namespace Discord
         /// </summary>
         public bool DefaultPermission { get; set; } = true;
 
-        private string _name { get; set; }
+        private string _name;
 
         /// <summary>
         ///     Build the current builder into a <see cref="MessageCommandProperties"/> class.
@@ -51,7 +41,7 @@ namespace Discord
         /// </returns>
         public MessageCommandProperties Build()
         {
-            MessageCommandProperties props = new MessageCommandProperties()
+            var props = new MessageCommandProperties
             {
                 Name = Name,
                 DefaultPermission = DefaultPermission
@@ -79,7 +69,7 @@ namespace Discord
         /// </summary>
         /// <param name="value">The default permission value to set.</param>
         /// <returns>The current builder.</returns>
-        public MessageCommandBuilder WithDefaultPermission (bool value)
+        public MessageCommandBuilder WithDefaultPermission(bool value)
         {
             DefaultPermission = value;
             return this;

--- a/src/Discord.Net.Core/Entities/Interactions/Context Menus/MessageCommandProperties.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Context Menus/MessageCommandProperties.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>

--- a/src/Discord.Net.Core/Entities/Interactions/Context Menus/UserCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Context Menus/UserCommandBuilder.cs
@@ -46,7 +46,6 @@ namespace Discord
             };
 
             return props;
-
         }
 
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Interactions/Context Menus/UserCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Context Menus/UserCommandBuilder.cs
@@ -1,10 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>
@@ -12,7 +5,7 @@ namespace Discord
     /// </summary>
     public class UserCommandBuilder
     {
-        /// <summary> 
+        /// <summary>
         ///     Returns the maximum length a commands name allowed by Discord
         /// </summary>
         public const int MaxNameLength = 32;
@@ -22,10 +15,7 @@ namespace Discord
         /// </summary>
         public string Name
         {
-            get
-            {
-                return _name;
-            }
+            get => _name;
             set
             {
                 Preconditions.NotNullOrEmpty(value, nameof(Name));
@@ -41,7 +31,7 @@ namespace Discord
         /// </summary>
         public bool DefaultPermission { get; set; } = true;
 
-        private string _name { get; set; }
+        private string _name;
 
         /// <summary>
         ///     Build the current builder into a <see cref="UserCommandProperties"/> class.
@@ -49,7 +39,7 @@ namespace Discord
         /// <returns>A <see cref="UserCommandProperties"/> that can be used to create user commands.</returns>
         public UserCommandProperties Build()
         {
-            UserCommandProperties props = new UserCommandProperties()
+            var props = new UserCommandProperties
             {
                 Name = Name,
                 DefaultPermission = DefaultPermission
@@ -77,7 +67,7 @@ namespace Discord
         /// </summary>
         /// <param name="value">The default permission value to set.</param>
         /// <returns>The current builder.</returns>
-        public UserCommandBuilder WithDefaultPermission (bool value)
+        public UserCommandBuilder WithDefaultPermission(bool value)
         {
             DefaultPermission = value;
             return this;

--- a/src/Discord.Net.Core/Entities/Interactions/Context Menus/UserCommandProperties.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Context Menus/UserCommandProperties.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>

--- a/src/Discord.Net.Core/Entities/Interactions/IApplicationCommand.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IApplicationCommand.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Discord
@@ -17,7 +15,7 @@ namespace Discord
         ulong ApplicationId { get; }
 
         /// <summary>
-        ///     The type of the command
+        ///     The type of the command.
         /// </summary>
         ApplicationCommandType Type { get; }
 

--- a/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandInteractionData.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandInteractionData.cs
@@ -1,8 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord
 {

--- a/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandInteractionDataOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandInteractionDataOption.cs
@@ -1,8 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord
 {

--- a/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandInteractionDataOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandInteractionDataOption.cs
@@ -29,6 +29,5 @@ namespace Discord
         ///     Present if this option is a group or subcommand.
         /// </summary>
         IReadOnlyCollection<IApplicationCommandInteractionDataOption> Options { get; }
-
     }
 }

--- a/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandOption.cs
@@ -1,8 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord
 {
@@ -39,16 +35,16 @@ namespace Discord
         /// <summary>
         ///     Choices for string and int types for the user to pick from.
         /// </summary>
-        IReadOnlyCollection<IApplicationCommandOptionChoice>? Choices { get; }
+        IReadOnlyCollection<IApplicationCommandOptionChoice> Choices { get; }
 
         /// <summary>
         ///     If the option is a subcommand or subcommand group type, this nested options will be the parameters.
         /// </summary>
-        IReadOnlyCollection<IApplicationCommandOption>? Options { get; }
+        IReadOnlyCollection<IApplicationCommandOption> Options { get; }
 
         /// <summary>
         ///     The allowed channel types for this option.
         /// </summary>
-        IReadOnlyCollection<ChannelType>? ChannelTypes { get; }
+        IReadOnlyCollection<ChannelType> ChannelTypes { get; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandOptionChoice.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandOptionChoice.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>

--- a/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandOptionChoice.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandOptionChoice.cs
@@ -14,6 +14,5 @@ namespace Discord
         ///     value of the choice.
         /// </summary>
         object Value { get; }
-
     }
 }

--- a/src/Discord.Net.Core/Entities/Interactions/IDiscordInteraction.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IDiscordInteraction.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Discord
@@ -51,7 +48,7 @@ namespace Discord
         /// <param name="options">The request options for this response.</param>
         /// <param name="component">A <see cref="MessageComponent"/> to be sent with this response.</param>
         /// <param name="embed">A single embed to send with this response. If this is passed alongside an array of embeds, the single embed will be ignored.</param>
-        Task RespondAsync (string text = null, Embed[] embeds = null, bool isTTS = false,
+        Task RespondAsync(string text = null, Embed[] embeds = null, bool isTTS = false,
             bool ephemeral = false, AllowedMentions allowedMentions = null, RequestOptions options = null, MessageComponent component = null, Embed embed = null);
 
         /// <summary>
@@ -68,7 +65,7 @@ namespace Discord
         /// <returns>
         ///     The sent message.
         /// </returns>
-        Task<IUserMessage> FollowupAsync (string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false,
+        Task<IUserMessage> FollowupAsync(string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false,
              AllowedMentions allowedMentions = null, RequestOptions options = null, MessageComponent component = null, Embed embed = null);
 
         /// <summary>
@@ -76,7 +73,7 @@ namespace Discord
         /// </summary>
         /// <param name="options">The request options for this <see langword="async"/> request.</param>
         /// <returns>A <see cref="IUserMessage"/> that represents the initial response.</returns>
-        Task<IUserMessage> GetOriginalResponseAsync (RequestOptions options = null);
+        Task<IUserMessage> GetOriginalResponseAsync(RequestOptions options = null);
 
         /// <summary>
         ///     Edits original response for this interaction.
@@ -84,7 +81,7 @@ namespace Discord
         /// <param name="func">A delegate containing the properties to modify the message with.</param>
         /// <param name="options">The request options for this <see langword="async"/> request.</param>
         /// <returns>A <see cref="IUserMessage"/> that represents the initial response.</returns>
-        Task<IUserMessage> ModifyOriginalResponseAsync (Action<MessageProperties> func, RequestOptions options = null);
+        Task<IUserMessage> ModifyOriginalResponseAsync(Action<MessageProperties> func, RequestOptions options = null);
 
         /// <summary>
         ///     Acknowledges this interaction.
@@ -92,6 +89,6 @@ namespace Discord
         /// <returns>
         ///     A task that represents the asynchronous operation of acknowledging the interaction.
         /// </returns>
-        Task DeferAsync (bool ephemeral = false, RequestOptions options = null);
+        Task DeferAsync(bool ephemeral = false, RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Core/Entities/Interactions/IDiscordInteractionData.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IDiscordInteractionData.cs
@@ -1,13 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>
-    ///     Represents an interface used to specify classes that they are a vaild data type of a <see cref="IDiscordInteraction"/> class.
+    ///     Represents an interface used to specify classes that they are a valid data type of a <see cref="IDiscordInteraction"/> class.
     /// </summary>
     public interface IDiscordInteractionData { }
 }

--- a/src/Discord.Net.Core/Entities/Interactions/InteractionResponseType.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/InteractionResponseType.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord
 {
@@ -13,7 +9,7 @@ namespace Discord
     ///     After receiving an interaction, you must respond to acknowledge it. You can choose to respond with a message immediately using <see cref="ChannelMessageWithSource"/>
     ///     or you can choose to send a deferred response with <see cref="DeferredChannelMessageWithSource"/>. If choosing a deferred response, the user will see a loading state for the interaction,
     ///     and you'll have up to 15 minutes to edit the original deferred response using Edit Original Interaction Response.
-    ///     You can read more about Response types <see href="https://discord.com/developers/docs/interactions/slash-commands#interaction-response">Here</see>
+    ///     You can read more about Response types <see href="https://discord.com/developers/docs/interactions/slash-commands#interaction-response">Here</see>.
     /// </remarks>
     public enum InteractionResponseType : byte
     {
@@ -45,17 +41,17 @@ namespace Discord
         DeferredChannelMessageWithSource = 5,
 
         /// <summary>
-        ///     For components: ACK an interaction and edit the original message later; the user does not see a loading state
+        ///     For components: ACK an interaction and edit the original message later; the user does not see a loading state.
         /// </summary>
         DeferredUpdateMessage = 6,
 
         /// <summary>
-        ///     For components: edit the message the component was attached to
+        ///     For components: edit the message the component was attached to.
         /// </summary>
         UpdateMessage = 7,
 
         /// <summary>
-        ///     Respond with a set of choices to a autocomplete interaction
+        ///     Respond with a set of choices to a autocomplete interaction.
         /// </summary>
         ApplicationCommandAutocompleteResult = 8
     }

--- a/src/Discord.Net.Core/Entities/Interactions/InteractionType.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/InteractionType.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>
@@ -29,6 +23,6 @@ namespace Discord
         /// <summary>
         ///     An autocomplete request sent from discord.
         /// </summary>
-        ApplicationCommandAutocomplete = 4,
+        ApplicationCommandAutocomplete = 4
     }
 }

--- a/src/Discord.Net.Core/Entities/Interactions/Message Components/ActionRowComponent.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Message Components/ActionRowComponent.cs
@@ -1,26 +1,21 @@
-using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord
 {
     /// <summary>
-    ///     Represents a <see cref="IMessageComponent"/> Row for child components to live in. 
+    ///     Represents a <see cref="IMessageComponent"/> Row for child components to live in.
     /// </summary>
     public class ActionRowComponent : IMessageComponent
     {
         /// <inheritdoc/>
-        public ComponentType Type { get; } = ComponentType.ActionRow;
+        public ComponentType Type => ComponentType.ActionRow;
 
         /// <summary>
         ///     The child components in this row.
         /// </summary>
         public IReadOnlyCollection<IMessageComponent> Components { get; internal set; }
 
-        
+
 
         internal ActionRowComponent() { }
         internal ActionRowComponent(List<IMessageComponent> components)

--- a/src/Discord.Net.Core/Entities/Interactions/Message Components/ActionRowComponent.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Message Components/ActionRowComponent.cs
@@ -15,9 +15,8 @@ namespace Discord
         /// </summary>
         public IReadOnlyCollection<IMessageComponent> Components { get; internal set; }
 
-
-
         internal ActionRowComponent() { }
+
         internal ActionRowComponent(List<IMessageComponent> components)
         {
             Components = components;

--- a/src/Discord.Net.Core/Entities/Interactions/Message Components/ButtonComponent.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Message Components/ButtonComponent.cs
@@ -1,10 +1,3 @@
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>
@@ -13,7 +6,7 @@ namespace Discord
     public class ButtonComponent : IMessageComponent
     {
         /// <inheritdoc/>
-        public ComponentType Type { get; } = ComponentType.Button;
+        public ComponentType Type => ComponentType.Button;
 
         /// <summary>
         ///     The <see cref="ButtonStyle"/> of this button, example buttons with each style can be found <see href="https://discord.com/assets/7bb017ce52cfd6575e21c058feb3883b.png">Here</see>.
@@ -36,7 +29,7 @@ namespace Discord
         public string CustomId { get; }
 
         /// <summary>
-        ///     A URL for a <see cref="ButtonStyle.Link"/> button. 
+        ///     A URL for a <see cref="ButtonStyle.Link"/> button.
         /// </summary>
         /// <remarks>
         ///     You cannot have a button with a <b>URL</b> and a <b>CustomId</b>.

--- a/src/Discord.Net.Core/Entities/Interactions/Message Components/ButtonStyle.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Message Components/ButtonStyle.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>

--- a/src/Discord.Net.Core/Entities/Interactions/Message Components/ComponentBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Message Components/ComponentBuilder.cs
@@ -402,7 +402,6 @@ namespace Discord
         /// </summary>
         public bool Disabled { get; set; }
 
-
         private string _label;
         private string _customId;
 

--- a/src/Discord.Net.Core/Entities/Interactions/Message Components/ComponentBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Message Components/ComponentBuilder.cs
@@ -31,7 +31,7 @@ namespace Discord
             set
             {
                 if (value == null)
-                    throw new ArgumentNullException(nameof(value));
+                    throw new ArgumentNullException(nameof(value), $"{nameof(ActionRows)} cannot be null.");
                 if (value.Count > MaxActionRowCount)
                     throw new ArgumentOutOfRangeException(nameof(value), $"Action row count must be less than or equal to {MaxActionRowCount}.");
                 _actionRows = value;
@@ -272,7 +272,7 @@ namespace Discord
             set
             {
                 if (value == null)
-                    throw new ArgumentNullException(nameof(value));
+                    throw new ArgumentNullException(nameof(value), $"{nameof(Components)} cannot be null.");
 
                 _components = value.Count switch
                 {
@@ -683,7 +683,7 @@ namespace Discord
                 if (value != null)
                     Preconditions.LessThan(value.Count, MaxOptionCount, nameof(Options));
                 else
-                    throw new ArgumentNullException(nameof(value));
+                    throw new ArgumentNullException(nameof(value), $"{nameof(Options)} cannot be null.");
 
                 _options = value;
             }

--- a/src/Discord.Net.Core/Entities/Interactions/Message Components/ComponentBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Message Components/ComponentBuilder.cs
@@ -31,14 +31,14 @@ namespace Discord
             set
             {
                 if (value == null)
-                    throw new ArgumentNullException(paramName: nameof(ActionRows), message: "Cannot set an component builder's components collection to null.");
+                    throw new ArgumentNullException(nameof(value));
                 if (value.Count > MaxActionRowCount)
-                    throw new ArgumentException(message: $"Action row count must be less than or equal to {MaxActionRowCount}.", paramName: nameof(ActionRows));
+                    throw new ArgumentOutOfRangeException(nameof(value), $"Action row count must be less than or equal to {MaxActionRowCount}.");
                 _actionRows = value;
             }
         }
 
-        private List<ActionRowBuilder> _actionRows { get; set; }
+        private List<ActionRowBuilder> _actionRows;
 
         /// <summary>
         ///     Creates a new builder from a message.
@@ -56,7 +56,7 @@ namespace Discord
         public static ComponentBuilder FromComponents(IReadOnlyCollection<IMessageComponent> components)
         {
             var builder = new ComponentBuilder();
-            for(int i = 0; i != components.Count; i++)
+            for (int i = 0; i != components.Count; i++)
             {
                 var component = components.ElementAt(i);
                 builder.AddComponent(component, i);
@@ -119,7 +119,7 @@ namespace Discord
         public ComponentBuilder WithSelectMenu(SelectMenuBuilder menu, int row = 0)
         {
             Preconditions.LessThan(row, MaxActionRowCount, nameof(row));
-            if (menu.Options.Distinct().Count() != menu.Options.Count())
+            if (menu.Options.Distinct().Count() != menu.Options.Count)
                 throw new InvalidOperationException("Please make sure that there is no duplicates values.");
 
             var builtMenu = menu.Build();
@@ -219,7 +219,7 @@ namespace Discord
                 else
                 {
                     ActionRowBuilder actionRow;
-                    if(_actionRows.Count > row)
+                    if (_actionRows.Count > row)
                         actionRow = _actionRows.ElementAt(row);
                     else
                     {
@@ -245,10 +245,9 @@ namespace Discord
         /// <returns>A <see cref="MessageComponent"/> that can be sent with <see cref="IMessageChannel.SendMessageAsync"/>.</returns>
         public MessageComponent Build()
         {
-            if (_actionRows != null)
-                return new MessageComponent(_actionRows.Select(x => x.Build()).ToList());
-            else
-                return MessageComponent.Empty;
+            return _actionRows != null
+                ? new MessageComponent(_actionRows.Select(x => x.Build()).ToList())
+                : MessageComponent.Empty;
         }
     }
 
@@ -273,19 +272,18 @@ namespace Discord
             set
             {
                 if (value == null)
-                    throw new ArgumentNullException(message: "Action row components cannot be null!", paramName: nameof(Components));
+                    throw new ArgumentNullException(nameof(value));
 
-                if (value.Count <= 0)
-                    throw new ArgumentException(message: "There must be at least 1 component in a row", paramName: nameof(Components));
-
-                if (value.Count > MaxChildCount)
-                    throw new ArgumentException(message: $"Action row can only contain {MaxChildCount} child components!", paramName: nameof(Components));
-
-                _components = value;
+                _components = value.Count switch
+                {
+                    0 => throw new ArgumentOutOfRangeException(nameof(value), "There must be at least 1 component in a row."),
+                    > MaxChildCount => throw new ArgumentOutOfRangeException(nameof(value), $"Action row can only contain {MaxChildCount} child components!"),
+                    _ => value
+                };
             }
         }
 
-        private List<IMessageComponent> _components { get; set; } = new List<IMessageComponent>();
+        private List<IMessageComponent> _components = new List<IMessageComponent>();
 
         /// <summary>
         ///     Adds a list of components to the current row.
@@ -360,18 +358,12 @@ namespace Discord
         public string Label
         {
             get => _label;
-            set
+            set => _label = value?.Length switch
             {
-                if (value != null)
-                {
-                    if (value.Length > MaxButtonLabelLength)
-                        throw new ArgumentException($"Button label must be {MaxButtonLabelLength} characters or less!", paramName: nameof(Label));
-                    if (value.Length < 1)
-                        throw new ArgumentException("Button label must be 1 character or more!", paramName: nameof(Label));
-                }
-
-                _label = value;
-            }
+                > MaxButtonLabelLength => throw new ArgumentOutOfRangeException(nameof(value), $"Label length must be less or equal to {MaxButtonLabelLength}."),
+                0 => throw new ArgumentOutOfRangeException(nameof(value), "Label length must be at least 1."),
+                _ => value
+            };
         }
 
         /// <summary>
@@ -382,17 +374,12 @@ namespace Discord
         public string CustomId
         {
             get => _customId;
-            set
+            set => _customId = value?.Length switch
             {
-                if (value != null)
-                {
-                    if (value.Length > ComponentBuilder.MaxCustomIdLength)
-                        throw new ArgumentException($"Custom Id must be {ComponentBuilder.MaxCustomIdLength} characters or less!", paramName: nameof(CustomId));
-                    if (value.Length < 1)
-                        throw new ArgumentException("Custom Id must be 1 character or more!", paramName: nameof(CustomId));
-                }
-                _customId = value;
-            }
+                > ComponentBuilder.MaxCustomIdLength => throw new ArgumentOutOfRangeException(nameof(value), $"Custom Id length must be less or equal to {ComponentBuilder.MaxCustomIdLength}."),
+                0 => throw new ArgumentOutOfRangeException(nameof(value), "Custom Id length must be at least 1."),
+                _ => value
+            };
         }
 
         /// <summary>
@@ -595,8 +582,7 @@ namespace Discord
             {
                 if (string.IsNullOrEmpty(Url))
                     throw new InvalidOperationException("Link buttons must have a link associated with them");
-                else
-                    UrlValidation.ValidateButton(Url);
+                UrlValidation.ValidateButton(Url);
             }
             else if (string.IsNullOrEmpty(CustomId))
                 throw new InvalidOperationException("Non-link buttons must have a custom id associated with them");
@@ -633,17 +619,12 @@ namespace Discord
         public string CustomId
         {
             get => _customId;
-            set
+            set => _customId = value?.Length switch
             {
-                if (value != null)
-                {
-                    if (value.Length > ComponentBuilder.MaxCustomIdLength)
-                        throw new ArgumentException($"Custom Id must be {ComponentBuilder.MaxCustomIdLength} characters or less!", paramName: nameof(CustomId));
-                    if (value.Length < 1)
-                        throw new ArgumentException("Custom Id must be 1 character or more!", paramName: nameof(CustomId));
-                }
-                _customId = value;
-            }
+                > ComponentBuilder.MaxCustomIdLength => throw new ArgumentOutOfRangeException(nameof(value), $"Custom Id length must be less or equal to {ComponentBuilder.MaxCustomIdLength}."),
+                0 => throw new ArgumentOutOfRangeException(nameof(value), "Custom Id length must be at least 1."),
+                _ => value
+            };
         }
 
         /// <summary>
@@ -654,18 +635,12 @@ namespace Discord
         public string Placeholder
         {
             get => _placeholder;
-            set
+            set => _placeholder = value?.Length switch
             {
-                if (value != null)
-                {
-                    if (value.Length > MaxPlaceholderLength)
-                        throw new ArgumentException($"The placeholder must be {MaxPlaceholderLength} characters or less!", paramName: nameof(Placeholder));
-                    if (value.Length < 1)
-                        throw new ArgumentException("The placeholder must be 1 character or more!", paramName: nameof(Placeholder));
-                }
-
-                _placeholder = value;
-            }
+                > MaxPlaceholderLength => throw new ArgumentOutOfRangeException(nameof(value), $"Placeholder length must be less or equal to {MaxPlaceholderLength}."),
+                0 => throw new ArgumentOutOfRangeException(nameof(value), "Placeholder length must be at least 1."),
+                _ => value
+            };
         }
 
         /// <summary>
@@ -909,7 +884,7 @@ namespace Discord
         ///     The maximum length of a <see cref="SelectMenuOption.Description"/>.
         /// </summary>
         public const int MaxDescriptionLength = 100;
-        
+
         /// <summary>
         ///     The maximum length of a <see cref="SelectMenuOption.Value"/>.
         /// </summary>
@@ -923,42 +898,28 @@ namespace Discord
         public string Label
         {
             get => _label;
-            set
+            set => _label = value?.Length switch
             {
-                if (value != null)
-                {
-                    if (value.Length > MaxSelectLabelLength)
-                        throw new ArgumentException($"Select option label must be {MaxSelectLabelLength} characters or less!", paramName: nameof(Label));
-                    if (value.Length < 1)
-                        throw new ArgumentException("Select option label must be 1 character or more!", paramName: nameof(Label));
-                }
-
-                _label = value;
-            }
+                > MaxSelectLabelLength => throw new ArgumentOutOfRangeException(nameof(value), $"Label length must be less or equal to {MaxSelectLabelLength}."),
+                0 => throw new ArgumentOutOfRangeException(nameof(value), "Label length must be at least 1."),
+                _ => value
+            };
         }
 
         /// <summary>
-        ///     Gets or sets the custom id of the current select menu.
+        ///     Gets or sets the value of the current select menu.
         /// </summary>
         /// <exception cref="ArgumentException" accessor="set"><see cref="Value"/> length exceeds <see cref="MaxSelectValueLength"/>.</exception>
         /// <exception cref="ArgumentException" accessor="set"><see cref="Value"/> length subceeds 1.</exception>
         public string Value
         {
             get => _value;
-            set
+            set => _value = value?.Length switch
             {
-                if (value != null)
-                {
-                    if (value.Length > MaxSelectValueLength)
-                        throw new ArgumentException($"Select option value must be {MaxSelectValueLength} characters or less!", paramName: nameof(Label));
-                    if (value.Length < 1)
-                        throw new ArgumentException("Select option value must be 1 character or more!", paramName: nameof(Label));
-                }
-                else
-                    throw new ArgumentException("Select option value must not be null or empty!", paramName: nameof(Label));
-
-                _value = value;
-            }
+                > MaxSelectValueLength => throw new ArgumentOutOfRangeException(nameof(value), $"Value length must be less or equal to {MaxSelectValueLength}."),
+                0 => throw new ArgumentOutOfRangeException(nameof(value), "Value length must be at least 1."),
+                _ => value
+            };
         }
 
         /// <summary>
@@ -969,18 +930,12 @@ namespace Discord
         public string Description
         {
             get => _description;
-            set
+            set => _description = value?.Length switch
             {
-                if (value != null)
-                {
-                    if (value.Length > MaxDescriptionLength)
-                        throw new ArgumentException($"The description must be {MaxDescriptionLength} characters or less!", paramName: nameof(Label));
-                    if (value.Length < 1)
-                        throw new ArgumentException("The description must be 1 character or more!", paramName: nameof(Label));
-                }
-
-                _description = value;
-            }
+                > MaxDescriptionLength => throw new ArgumentOutOfRangeException(nameof(value), $"Description length must be less or equal to {MaxDescriptionLength}."),
+                0 => throw new ArgumentOutOfRangeException(nameof(value), "Description length must be at least 1."),
+                _ => value
+            };
         }
 
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Interactions/Message Components/ComponentType.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Message Components/ComponentType.cs
@@ -1,29 +1,23 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>
-    ///     Represents a type of a component
+    ///     Represents a type of a component.
     /// </summary>
     public enum ComponentType
     {
         /// <summary>
-        ///     A container for other components
+        ///     A container for other components.
         /// </summary>
         ActionRow = 1,
 
         /// <summary>
-        ///     A clickable button
+        ///     A clickable button.
         /// </summary>
         Button = 2,
 
         /// <summary>
-        ///     A select menu for picking from choices
+        ///     A select menu for picking from choices.
         /// </summary>
-        SelectMenu = 3,
+        SelectMenu = 3
     }
 }

--- a/src/Discord.Net.Core/Entities/Interactions/Message Components/IMessageComponent.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Message Components/IMessageComponent.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>

--- a/src/Discord.Net.Core/Entities/Interactions/Message Components/MessageComponent.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Message Components/MessageComponent.cs
@@ -1,8 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord
 {

--- a/src/Discord.Net.Core/Entities/Interactions/Message Components/SelectMenuComponent.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Message Components/SelectMenuComponent.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord
 {

--- a/src/Discord.Net.Core/Entities/Interactions/Message Components/SelectMenuOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Message Components/SelectMenuOption.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>

--- a/src/Discord.Net.Core/Entities/Interactions/Slash Commands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Slash Commands/SlashCommandBuilder.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 
 namespace Discord
 {
@@ -30,20 +28,17 @@ namespace Discord
         /// </summary>
         public string Name
         {
-            get
-            {
-                return _name;
-            }
+            get => _name;
             set
             {
-                Preconditions.NotNullOrEmpty(value, nameof(Name));
-                Preconditions.AtLeast(value.Length, 1, nameof(Name));
-                Preconditions.AtMost(value.Length, MaxNameLength, nameof(Name));
+                Preconditions.NotNullOrEmpty(value, nameof(value));
+                Preconditions.AtLeast(value.Length, 1, nameof(value));
+                Preconditions.AtMost(value.Length, MaxNameLength, nameof(value));
 
                 // Discord updated the docs, this regex prevents special characters like @!$%(... etc,
                 // https://discord.com/developers/docs/interactions/slash-commands#applicationcommand
                 if (!Regex.IsMatch(value, @"^[\w-]{1,32}$"))
-                    throw new ArgumentException("Command name cannot contain any special characters or whitespaces!");
+                    throw new ArgumentException("Command name cannot contain any special characters or whitespaces!", nameof(value));
 
                 _name = value;
             }
@@ -55,10 +50,7 @@ namespace Discord
         /// </summary>
         public string Description
         {
-            get
-            {
-                return _description;
-            }
+            get => _description;
             set
             {
                 Preconditions.NotNullOrEmpty(value, nameof(Description));
@@ -77,10 +69,7 @@ namespace Discord
             get => _options;
             set
             {
-                if (value != null)
-                    if (value.Count > MaxOptionsCount)
-                        throw new ArgumentException(message: $"Option count must be less than or equal to {MaxOptionsCount}.", paramName: nameof(Options));
-
+                Preconditions.AtMost(value?.Count ?? 0, MaxOptionsCount, nameof(value));
                 _options = value;
             }
         }
@@ -90,9 +79,9 @@ namespace Discord
         /// </summary>
         public bool DefaultPermission { get; set; } = true;
 
-        private string _name { get; set; }
-        private string _description { get; set; }
-        private List<SlashCommandOptionBuilder> _options { get; set; }
+        private string _name;
+        private string _description;
+        private List<SlashCommandOptionBuilder> _options;
 
         /// <summary>
         ///     Build the current builder into a <see cref="SlashCommandProperties"/> class.
@@ -100,11 +89,11 @@ namespace Discord
         /// <returns>A <see cref="SlashCommandProperties"/> that can be used to create slash commands over rest.</returns>
         public SlashCommandProperties Build()
         {
-            SlashCommandProperties props = new SlashCommandProperties()
+            var props = new SlashCommandProperties
             {
                 Name = Name,
                 Description = Description,
-                DefaultPermission = DefaultPermission,
+                DefaultPermission = DefaultPermission
             };
 
             if (Options != null && Options.Any())
@@ -163,7 +152,7 @@ namespace Discord
         /// <param name="description">The description of this option.</param>
         /// <param name="required">If this option is required for this command.</param>
         /// <param name="isDefault">If this option is the default option.</param>
-        /// <param name="isAutocomplete">If this option is set to autocompleate.</param>
+        /// <param name="isAutocomplete">If this option is set to autocomplete.</param>
         /// <param name="options">The options of the option to add.</param>
         /// <param name="channelTypes">The allowed channel types for this option.</param>
         /// <param name="choices">The choices of this option.</param>
@@ -188,14 +177,10 @@ namespace Discord
             Preconditions.AtMost(description.Length, MaxDescriptionLength, nameof(description));
 
             // make sure theres only one option with default set to true
-            if (isDefault.HasValue && isDefault.Value)
-            {
-                if (Options != null)
-                    if (Options.Any(x => x.Default.HasValue && x.Default.Value))
-                        throw new ArgumentException("There can only be one command option with default set to true!", nameof(isDefault));
-            }
+            if (isDefault == true && Options?.Any(x => x.Default == true) == true)
+                throw new ArgumentException("There can only be one command option with default set to true!", nameof(isDefault));
 
-            SlashCommandOptionBuilder option = new SlashCommandOptionBuilder
+            var option = new SlashCommandOptionBuilder
             {
                 Name = name,
                 Description = description,
@@ -204,8 +189,8 @@ namespace Discord
                 Options = options,
                 Type = type,
                 Autocomplete = isAutocomplete,
-                Choices = choices != null ? new List<ApplicationCommandOptionChoiceProperties>(choices) : null,
-                ChannelTypes = channelTypes,
+                Choices = (choices ?? Array.Empty<ApplicationCommandOptionChoiceProperties>()).ToList(),
+                ChannelTypes = channelTypes
             };
 
             return AddOption(option);
@@ -228,14 +213,12 @@ namespace Discord
         /// <returns>The current builder.</returns>
         public SlashCommandBuilder AddOption(SlashCommandOptionBuilder option)
         {
-            if (Options == null)
-                Options = new List<SlashCommandOptionBuilder>();
+            Options ??= new List<SlashCommandOptionBuilder>();
 
             if (Options.Count >= MaxOptionsCount)
-                throw new ArgumentOutOfRangeException(nameof(Options), $"Cannot have more than {MaxOptionsCount} options!");
+                throw new InvalidOperationException($"Cannot have more than {MaxOptionsCount} options!");
 
-            if (option == null)
-                throw new ArgumentNullException(nameof(option), "Option cannot be null");
+            Preconditions.NotNull(option, nameof(option));
 
             Options.Add(option);
             return this;
@@ -251,10 +234,9 @@ namespace Discord
                 throw new ArgumentNullException(nameof(options), "Options cannot be null!");
 
             if (options.Length == 0)
-                throw new ArgumentException(nameof(options), "Options cannot be empty!");
+                throw new ArgumentException("Options cannot be empty!", nameof(options));
 
-            if (Options == null)
-                Options = new List<SlashCommandOptionBuilder>();
+            Options ??= new List<SlashCommandOptionBuilder>();
 
             if (Options.Count + options.Length > MaxOptionsCount)
                 throw new ArgumentOutOfRangeException(nameof(options), $"Cannot have more than {MaxOptionsCount} options!");
@@ -290,14 +272,13 @@ namespace Discord
             get => _name;
             set
             {
-                if (value?.Length > SlashCommandBuilder.MaxNameLength)
-                    throw new ArgumentException($"Name length must be less than or equal to {SlashCommandBuilder.MaxNameLength}");
-                if (value?.Length < 1)
-                    throw new ArgumentException("Name length must at least 1 characters in length");
-
                 if (value != null)
+                {
+                    Preconditions.AtLeast(value.Length, 1, nameof(value));
+                    Preconditions.AtMost(value.Length, SlashCommandBuilder.MaxNameLength, nameof(value));
                     if (!Regex.IsMatch(value, @"^[\w-]{1,32}$"))
-                        throw new ArgumentException("Option name cannot contain any special characters or whitespaces!");
+                        throw new ArgumentException("Option name cannot contain any special characters or whitespaces!", nameof(value));
+                }
 
                 _name = value;
             }
@@ -311,10 +292,11 @@ namespace Discord
             get => _description;
             set
             {
-                if (value?.Length > SlashCommandBuilder.MaxDescriptionLength)
-                    throw new ArgumentException($"Description length must be less than or equal to {SlashCommandBuilder.MaxDescriptionLength}");
-                if (value?.Length < 1)
-                    throw new ArgumentException("Description length must at least 1 character in length");
+                if (value != null)
+                {
+                    Preconditions.AtLeast(value.Length, 1, nameof(value));
+                    Preconditions.AtMost(value.Length, SlashCommandBuilder.MaxDescriptionLength, nameof(value));
+                }
 
                 _description = value;
             }
@@ -333,7 +315,7 @@ namespace Discord
         /// <summary>
         ///     Gets or sets if the option is required.
         /// </summary>
-        public bool? Required { get; set; } = null;
+        public bool? Required { get; set; }
 
         /// <summary>
         ///     Gets or sets whether or not this option supports autocomplete.
@@ -364,19 +346,19 @@ namespace Discord
             bool isSubType = Type == ApplicationCommandOptionType.SubCommandGroup;
 
             if (isSubType && (Options == null || !Options.Any()))
-                throw new ArgumentException(nameof(Options), "SubCommands/SubCommandGroups must have at least one option");
+                throw new InvalidOperationException("SubCommands/SubCommandGroups must have at least one option");
 
-            if (!isSubType && (Options != null && Options.Any()) && Type != ApplicationCommandOptionType.SubCommand)
-                throw new ArgumentException(nameof(Options), $"Cannot have options on {Type} type");
+            if (!isSubType && Options != null && Options.Any() && Type != ApplicationCommandOptionType.SubCommand)
+                throw new InvalidOperationException($"Cannot have options on {Type} type");
 
-            return new ApplicationCommandOptionProperties()
+            return new ApplicationCommandOptionProperties
             {
                 Name = Name,
                 Description = Description,
                 Default = Default,
                 Required = Required,
                 Type = Type,
-                Options = Options?.Count > 0 ? new List<ApplicationCommandOptionProperties>(Options.Select(x => x.Build())) : null,
+                Options = Options?.Count > 0 ? Options.Select(x => x.Build()).ToList() : new List<ApplicationCommandOptionProperties>(),
                 Choices = Choices,
                 Autocomplete = Autocomplete,
                 ChannelTypes = ChannelTypes
@@ -416,14 +398,10 @@ namespace Discord
             Preconditions.AtMost(description.Length, SlashCommandBuilder.MaxDescriptionLength, nameof(description));
 
             // make sure theres only one option with default set to true
-            if (isDefault)
-            {
-                if (Options != null)
-                    if (Options.Any(x => x.Default.HasValue && x.Default.Value))
-                        throw new ArgumentException("There can only be one command option with default set to true!", nameof(isDefault));
-            }
+            if (isDefault && Options?.Any(x => x.Default == true) == true)
+                throw new ArgumentException("There can only be one command option with default set to true!", nameof(isDefault));
 
-            SlashCommandOptionBuilder option = new SlashCommandOptionBuilder
+            var option = new SlashCommandOptionBuilder
             {
                 Name = name,
                 Description = description,
@@ -432,8 +410,8 @@ namespace Discord
                 Autocomplete = isAutocomplete,
                 Options = options,
                 Type = type,
-                Choices = choices != null ? new List<ApplicationCommandOptionChoiceProperties>(choices) : null,
-                ChannelTypes = channelTypes,
+                Choices = (choices ?? Array.Empty<ApplicationCommandOptionChoiceProperties>()).ToList(),
+                ChannelTypes = channelTypes
             };
 
             return AddOption(option);
@@ -445,14 +423,12 @@ namespace Discord
         /// <returns>The current builder.</returns>
         public SlashCommandOptionBuilder AddOption(SlashCommandOptionBuilder option)
         {
-            if (Options == null)
-                Options = new List<SlashCommandOptionBuilder>();
+            Options ??= new List<SlashCommandOptionBuilder>();
 
             if (Options.Count >= SlashCommandBuilder.MaxOptionsCount)
-                throw new ArgumentOutOfRangeException(nameof(Choices), $"There can only be {SlashCommandBuilder.MaxOptionsCount} options per sub command group!");
+                throw new InvalidOperationException($"There can only be {SlashCommandBuilder.MaxOptionsCount} options per sub command group!");
 
-            if (option == null)
-                throw new ArgumentNullException(nameof(option), "Option cannot be null");
+            Preconditions.NotNull(option, nameof(option));
 
             Options.Add(option);
             return this;
@@ -466,19 +442,17 @@ namespace Discord
         /// <returns>The current builder.</returns>
         public SlashCommandOptionBuilder AddChoice(string name, int value)
         {
-            if (Choices == null)
-                Choices = new List<ApplicationCommandOptionChoiceProperties>();
+            Choices ??= new List<ApplicationCommandOptionChoiceProperties>();
 
             if (Choices.Count >= MaxChoiceCount)
-                throw new ArgumentOutOfRangeException(nameof(Choices), $"Cannot add more than {MaxChoiceCount} choices!");
+                throw new InvalidOperationException($"Cannot add more than {MaxChoiceCount} choices!");
 
-            if (name == null)
-                throw new ArgumentNullException($"{nameof(name)} cannot be null!");
+            Preconditions.NotNull(name, nameof(name));
 
             Preconditions.AtLeast(name.Length, 1, nameof(name));
             Preconditions.AtMost(name.Length, 100, nameof(name));
 
-            Choices.Add(new ApplicationCommandOptionChoiceProperties()
+            Choices.Add(new ApplicationCommandOptionChoiceProperties
             {
                 Name = name,
                 Value = value
@@ -495,17 +469,13 @@ namespace Discord
         /// <returns>The current builder.</returns>
         public SlashCommandOptionBuilder AddChoice(string name, string value)
         {
-            if (Choices == null)
-                Choices = new List<ApplicationCommandOptionChoiceProperties>();
+            Choices ??= new List<ApplicationCommandOptionChoiceProperties>();
 
             if (Choices.Count >= MaxChoiceCount)
-                throw new ArgumentOutOfRangeException(nameof(Choices), $"Cannot add more than {MaxChoiceCount} choices!");
+                throw new InvalidOperationException($"Cannot add more than {MaxChoiceCount} choices!");
 
-            if (name == null)
-                throw new ArgumentNullException($"{nameof(name)} cannot be null!");
-
-            if (value == null)
-                throw new ArgumentNullException($"{nameof(value)} cannot be null!");
+            Preconditions.NotNull(name, nameof(name));
+            Preconditions.NotNull(value, nameof(value));
 
             Preconditions.AtLeast(name.Length, 1, nameof(name));
             Preconditions.AtMost(name.Length, 100, nameof(name));
@@ -513,7 +483,7 @@ namespace Discord
             Preconditions.AtLeast(value.Length, 1, nameof(value));
             Preconditions.AtMost(value.Length, 100, nameof(value));
 
-            Choices.Add(new ApplicationCommandOptionChoiceProperties()
+            Choices.Add(new ApplicationCommandOptionChoiceProperties
             {
                 Name = name,
                 Value = value
@@ -523,14 +493,13 @@ namespace Discord
         }
 
         /// <summary>
-        ///     Adds a channnel type to the current option.
+        ///     Adds a channel type to the current option.
         /// </summary>
         /// <param name="channelType">The <see cref="ChannelType"/> to add.</param>
         /// <returns>The current builder.</returns>
         public SlashCommandOptionBuilder AddChannelType(ChannelType channelType)
         {
-            if (ChannelTypes == null)
-                ChannelTypes = new List<ChannelType>();
+            ChannelTypes ??= new List<ChannelType>();
 
             ChannelTypes.Add(channelType);
 

--- a/src/Discord.Net.Core/Entities/Interactions/Slash Commands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Slash Commands/SlashCommandBuilder.cs
@@ -106,7 +106,6 @@ namespace Discord
             }
 
             return props;
-
         }
 
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Interactions/Slash Commands/SlashCommandProperties.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Slash Commands/SlashCommandProperties.cs
@@ -1,8 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord
 {

--- a/src/Discord.Net.Core/Entities/Messages/StickerFormatType.cs
+++ b/src/Discord.Net.Core/Entities/Messages/StickerFormatType.cs
@@ -1,15 +1,25 @@
 namespace Discord
 {
-    /// <summary> Defines the types of formats for stickers. </summary>
+    /// <summary>
+    ///     Defines the types of formats for stickers.
+    /// </summary>
     public enum StickerFormatType
     {
-        /// <summary> Default value for a sticker format type. </summary>
+        /// <summary>
+        ///     Default value for a sticker format type.
+        /// </summary>
         None = 0,
-        /// <summary> The sticker format type is png. </summary>
+        /// <summary>
+        ///     The sticker format type is png.
+        /// </summary>
         Png = 1,
-        /// <summary> The sticker format type is apng. </summary>
+        /// <summary>
+        ///     The sticker format type is apng.
+        /// </summary>
         Apng = 2,
-        /// <summary> The sticker format type is lottie. </summary>
-        Lottie = 3,
+        /// <summary>
+        ///     The sticker format type is lottie.
+        /// </summary>
+        Lottie = 3
     }
 }

--- a/src/Discord.Net.Core/Entities/Messages/TimestampTag.cs
+++ b/src/Discord.Net.Core/Entities/Messages/TimestampTag.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord
 {
@@ -24,18 +20,13 @@ namespace Discord
         /// <summary>
         ///     Converts the current timestamp tag to the string representation supported by discord.
         ///     <para>
-        ///         If the <see cref="TimestampTag.Time"/> is null then the default 0 will be used.
+        ///         If the <see cref="Time"/> is null then the default 0 will be used.
         ///     </para>
         /// </summary>
-        /// <returns>A string thats compatible in a discord message, ex: <code>&lt;t:1625944201:f&gt;</code></returns>
+        /// <returns>A string that is compatible in a discord message, ex: <code>&lt;t:1625944201:f&gt;</code></returns>
         public override string ToString()
         {
-            if (Time == null)
-                return $"<t:0:{(char)Style}>";
-
-            var offset = (DateTimeOffset)this.Time;
-
-            return $"<t:{offset.ToUnixTimeSeconds()}:{(char)Style}>";
+            return $"<t:{((DateTimeOffset)Time).ToUnixTimeSeconds()}:{(char)Style}>";
         }
 
         /// <summary>
@@ -46,7 +37,7 @@ namespace Discord
         /// <returns>The newly create timestamp tag.</returns>
         public static TimestampTag FromDateTime(DateTime time, TimestampTagStyles style = TimestampTagStyles.ShortDateTime)
         {
-            return new TimestampTag()
+            return new TimestampTag
             {
                 Style = style,
                 Time = time

--- a/src/Discord.Net.Core/Entities/Messages/TimestampTagStyle.cs
+++ b/src/Discord.Net.Core/Entities/Messages/TimestampTagStyle.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>

--- a/src/Discord.Net.Core/Entities/Permissions/ApplicationCommandPermissionTarget.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/ApplicationCommandPermissionTarget.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>
@@ -18,6 +12,6 @@ namespace Discord
         /// <summary>
         ///     The target of the permission is a user.
         /// </summary>
-        User = 2,
+        User = 2
     }
 }

--- a/src/Discord.Net.Core/Entities/Permissions/GuildApplicationCommandPermissions.cs
+++ b/src/Discord.Net.Core/Entities/Permissions/GuildApplicationCommandPermissions.cs
@@ -1,8 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord
 {

--- a/src/Discord.Net.Core/Entities/Stickers/ICustomSticker.cs
+++ b/src/Discord.Net.Core/Entities/Stickers/ICustomSticker.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Discord

--- a/src/Discord.Net.Core/Entities/Stickers/ISticker.cs
+++ b/src/Discord.Net.Core/Entities/Stickers/ISticker.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace Discord
 {
@@ -57,12 +55,12 @@ namespace Discord
         new StickerFormatType Format { get; }
 
         /// <summary>
-        ///     Gets whether this guild sticker can be used, may be false due to loss of Server Boosts
+        ///     Gets whether this guild sticker can be used, may be false due to loss of Server Boosts.
         /// </summary>
         bool? IsAvailable { get; }
 
         /// <summary>
-        ///     Gets the standard sticker's sort order within its pack
+        ///     Gets the standard sticker's sort order within its pack.
         /// </summary>
         int? SortOrder { get; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Stickers/IStickerItem.cs
+++ b/src/Discord.Net.Core/Entities/Stickers/IStickerItem.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>

--- a/src/Discord.Net.Core/Entities/Stickers/StickerPack.cs
+++ b/src/Discord.Net.Core/Entities/Stickers/StickerPack.cs
@@ -1,16 +1,12 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord
 {
     /// <summary>
     ///     Represents a discord sticker pack.
     /// </summary>
-    /// <typeparam name="TSticker">The type of the stickers within the collection</typeparam>
+    /// <typeparam name="TSticker">The type of the stickers within the collection.</typeparam>
     public class StickerPack<TSticker> where TSticker : ISticker
     {
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Stickers/StickerProperties.cs
+++ b/src/Discord.Net.Core/Entities/Stickers/StickerProperties.cs
@@ -1,8 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord
 {

--- a/src/Discord.Net.Core/Entities/Stickers/StickerType.cs
+++ b/src/Discord.Net.Core/Entities/Stickers/StickerType.cs
@@ -1,13 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord
 {
     /// <summary>
-    ///     Represents a type of sticker
+    ///     Represents a type of sticker..
     /// </summary>
     public enum StickerType
     {
@@ -19,6 +13,6 @@ namespace Discord
         /// <summary>
         ///     Represents a sticker that was created within a guild.
         /// </summary>
-        Guild = 2,
+        Guild = 2
     }
 }

--- a/src/Discord.Net.Core/Net/ApplicationCommandException.cs
+++ b/src/Discord.Net.Core/Net/ApplicationCommandException.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.Net
 {

--- a/src/Discord.Net.Core/Utils/UrlValidation.cs
+++ b/src/Discord.Net.Core/Utils/UrlValidation.cs
@@ -2,38 +2,38 @@ using System;
 
 namespace Discord.Utils
 {
-    static class UrlValidation
+    internal static class UrlValidation
     {
         /// <summary>
         /// Not full URL validation right now. Just ensures protocol is present and that it's either http or https
-        /// <see cref="ValidateButton(string)"/> should be used for url buttons
+        /// <see cref="ValidateButton(string)"/> should be used for url buttons.
         /// </summary>
-        /// <param name="url">url to validate before sending to Discord.</param>
+        /// <param name="url">The URL to validate before sending to Discord.</param>
         /// <exception cref="InvalidOperationException">A URL must include a protocol (http or https).</exception>
-        /// <returns>true if url is valid by our standard, false if null, throws an error upon invalid </returns>
+        /// <returns>true if URL is valid by our standard, false if null, throws an error upon invalid.</returns>
         public static bool Validate(string url)
         {
             if (string.IsNullOrEmpty(url))
                 return false;
-            if(!(url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) || (url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))))
+            if (!(url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) || url.StartsWith("https://", StringComparison.OrdinalIgnoreCase)))
                 throw new InvalidOperationException($"The url {url} must include a protocol (either HTTP or HTTPS)");
             return true;
         }
 
         /// <summary>
         /// Not full URL validation right now. Just Ensures the protocol is either http, https, or discord
-        /// <see cref="Validate(string)"/> should be used everything other than url buttons
+        /// <see cref="Validate(string)"/> should be used everything other than url buttons.
         /// </summary>
-        /// <param name="url">the url to validate before sending to discord</param>
+        /// <param name="url">The URL to validate before sending to discord.</param>
         /// <exception cref="InvalidOperationException">A URL must include a protocol (either http, https, or discord).</exception>
-        /// <returns>true if the url is valid by our standard, false if null, throws an error upon invalid</returns>
+        /// <returns>true if the URL is valid by our standard, false if null, throws an error upon invalid.</returns>
         public static bool ValidateButton(string url)
         {
             if (string.IsNullOrEmpty(url))
                 return false;
-            if(!((url.StartsWith("http://", StringComparison.OrdinalIgnoreCase)) || 
-                (url.StartsWith("https://", StringComparison.OrdinalIgnoreCase)) || 
-                (url.StartsWith("discord://", StringComparison.OrdinalIgnoreCase))))
+            if (!(url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+                url.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ||
+                url.StartsWith("discord://", StringComparison.OrdinalIgnoreCase)))
                 throw new InvalidOperationException($"The url {url} must include a protocol (either HTTP, HTTPS, or DISCORD)");
             return true;
         }

--- a/src/Discord.Net.Rest/API/Common/ActionRowComponent.cs
+++ b/src/Discord.Net.Rest/API/Common/ActionRowComponent.cs
@@ -1,10 +1,5 @@
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {
@@ -26,7 +21,7 @@ namespace Discord.API
                 {
                     ComponentType.Button => new ButtonComponent(x as Discord.ButtonComponent),
                     ComponentType.SelectMenu => new SelectMenuComponent(x as Discord.SelectMenuComponent),
-                    _ => null,
+                    _ => null
                 };
             }).ToArray();
         }

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommand.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommand.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionData.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionData.cs
@@ -1,5 +1,4 @@
 using Newtonsoft.Json;
-using System.Collections.Generic;
 
 namespace Discord.API
 {

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionData.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionData.cs
@@ -18,6 +18,5 @@ namespace Discord.API
 
         [JsonProperty("type")]
         public ApplicationCommandType Type { get; set; }
-
     }
 }

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionDataOption.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandInteractionDataOption.cs
@@ -1,5 +1,4 @@
 using Newtonsoft.Json;
-using System.Collections.Generic;
 
 namespace Discord.API
 {

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandOption.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandOption.cs
@@ -1,9 +1,5 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {
@@ -40,7 +36,7 @@ namespace Discord.API
 
         public ApplicationCommandOption(IApplicationCommandOption cmd)
         {
-            Choices = cmd.Choices.Select(x => new ApplicationCommandOptionChoice()
+            Choices = cmd.Choices.Select(x => new ApplicationCommandOptionChoice
             {
                 Name = x.Name,
                 Value = x.Value
@@ -50,42 +46,28 @@ namespace Discord.API
 
             ChannelTypes = cmd.ChannelTypes.ToArray();
 
-            Required = cmd.IsRequired.HasValue
-                ? cmd.IsRequired.Value
-                : Optional<bool>.Unspecified;
-            Default = cmd.IsDefault.HasValue
-                ? cmd.IsDefault.Value
-                : Optional<bool>.Unspecified;
+            Required = cmd.IsRequired ?? Optional<bool>.Unspecified;
+            Default = cmd.IsDefault ?? Optional<bool>.Unspecified;
 
             Name = cmd.Name;
             Type = cmd.Type;
             Description = cmd.Description;
         }
-        public ApplicationCommandOption(Discord.ApplicationCommandOptionProperties option)
+        public ApplicationCommandOption(ApplicationCommandOptionProperties option)
         {
-            Choices = option.Choices != null
-                ? option.Choices.Select(x => new ApplicationCommandOptionChoice()
-                {
-                    Name = x.Name,
-                    Value = x.Value
-                }).ToArray()
-                : Optional<ApplicationCommandOptionChoice[]>.Unspecified;
+            Choices = option.Choices?.Select(x => new ApplicationCommandOptionChoice
+            {
+                Name = x.Name,
+                Value = x.Value
+            }).ToArray() ?? Optional<ApplicationCommandOptionChoice[]>.Unspecified;
 
-            Options = option.Options != null
-                ? option.Options.Select(x => new ApplicationCommandOption(x)).ToArray()
-                : Optional<ApplicationCommandOption[]>.Unspecified;
+            Options = option.Options?.Select(x => new ApplicationCommandOption(x)).ToArray() ?? Optional<ApplicationCommandOption[]>.Unspecified;
 
-            Required = option.Required.HasValue
-                ? option.Required.Value
-                : Optional<bool>.Unspecified;
+            Required = option.Required ?? Optional<bool>.Unspecified;
 
-            Default = option.Default.HasValue
-                ? option.Default.Value
-                : Optional<bool>.Unspecified;
+            Default = option.Default ?? Optional<bool>.Unspecified;
 
-            ChannelTypes = option.ChannelTypes != null
-                ? option.ChannelTypes.ToArray()
-                : Optional<ChannelType[]>.Unspecified;
+            ChannelTypes = option.ChannelTypes?.ToArray() ?? Optional<ChannelType[]>.Unspecified;
 
             Name = option.Name;
             Type = option.Type;

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandOptionChoice.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandOptionChoice.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandPermissions.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandPermissions.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {

--- a/src/Discord.Net.Rest/API/Common/AutocompleteInteractionData.cs
+++ b/src/Discord.Net.Rest/API/Common/AutocompleteInteractionData.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {

--- a/src/Discord.Net.Rest/API/Common/AutocompleteInteractionDataOption.cs
+++ b/src/Discord.Net.Rest/API/Common/AutocompleteInteractionDataOption.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {

--- a/src/Discord.Net.Rest/API/Common/ButtonComponent.cs
+++ b/src/Discord.Net.Rest/API/Common/ButtonComponent.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {
@@ -45,16 +40,16 @@ namespace Discord.API
             {
                 if (c.Emote is Emote e)
                 {
-                    Emote = new Emoji()
+                    Emote = new Emoji
                     {
                         Name = e.Name,
                         Animated = e.Animated,
-                        Id = e.Id,
+                        Id = e.Id
                     };
                 }
                 else
                 {
-                    Emote = new Emoji()
+                    Emote = new Emoji
                     {
                         Name = c.Emote.Name
                     };

--- a/src/Discord.Net.Rest/API/Common/ChannelThreads.cs
+++ b/src/Discord.Net.Rest/API/Common/ChannelThreads.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API.Rest
 {

--- a/src/Discord.Net.Rest/API/Common/GuildApplicationCommandPermissions.cs
+++ b/src/Discord.Net.Rest/API/Common/GuildApplicationCommandPermissions.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {
@@ -19,6 +14,6 @@ namespace Discord.API
         public ulong GuildId { get; set; }
 
         [JsonProperty("permissions")]
-        public API.ApplicationCommandPermissions[] Permissions { get; set; }
+        public ApplicationCommandPermissions[] Permissions { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Interaction.cs
+++ b/src/Discord.Net.Rest/API/Common/Interaction.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {

--- a/src/Discord.Net.Rest/API/Common/InteractionCallbackData.cs
+++ b/src/Discord.Net.Rest/API/Common/InteractionCallbackData.cs
@@ -11,7 +11,7 @@ namespace Discord.API
         public Optional<string> Content { get; set; }
 
         [JsonProperty("embeds")]
-        public Optional<API.Embed[]> Embeds { get; set; }
+        public Optional<Embed[]> Embeds { get; set; }
 
         [JsonProperty("allowed_mentions")]
         public Optional<AllowedMentions> AllowedMentions { get; set; }
@@ -20,9 +20,9 @@ namespace Discord.API
         public Optional<MessageFlags> Flags { get; set; }
 
         [JsonProperty("components")]
-        public Optional<API.ActionRowComponent[]> Components { get; set; }
+        public Optional<ActionRowComponent[]> Components { get; set; }
 
         [JsonProperty("choices")]
-        public Optional<API.ApplicationCommandOptionChoice[]> Choices { get; set; }
+        public Optional<ApplicationCommandOptionChoice[]> Choices { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/InteractionResponse.cs
+++ b/src/Discord.Net.Rest/API/Common/InteractionResponse.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {

--- a/src/Discord.Net.Rest/API/Common/MessageComponentInteractionData.cs
+++ b/src/Discord.Net.Rest/API/Common/MessageComponentInteractionData.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {

--- a/src/Discord.Net.Rest/API/Common/NitroStickerPacks.cs
+++ b/src/Discord.Net.Rest/API/Common/NitroStickerPacks.cs
@@ -1,9 +1,5 @@
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {

--- a/src/Discord.Net.Rest/API/Common/SelectMenuComponent.cs
+++ b/src/Discord.Net.Rest/API/Common/SelectMenuComponent.cs
@@ -1,9 +1,5 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {

--- a/src/Discord.Net.Rest/API/Common/SelectMenuOption.cs
+++ b/src/Discord.Net.Rest/API/Common/SelectMenuOption.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {
@@ -36,23 +31,23 @@ namespace Discord.API
             {
                 if (option.Emote is Emote e)
                 {
-                    Emoji = new Emoji()
+                    Emoji = new Emoji
                     {
                         Name = e.Name,
                         Animated = e.Animated,
-                        Id = e.Id,
+                        Id = e.Id
                     };
                 }
                 else
                 {
-                    Emoji = new Emoji()
+                    Emoji = new Emoji
                     {
                         Name = option.Emote.Name
                     };
                 }
             }
 
-            Default = option.Default.HasValue ? option.Default.Value : Optional<bool>.Unspecified;
+            Default = option.Default ?? Optional<bool>.Unspecified;
         }
     }
 }

--- a/src/Discord.Net.Rest/API/Common/StageInstance.cs
+++ b/src/Discord.Net.Rest/API/Common/StageInstance.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {

--- a/src/Discord.Net.Rest/API/Common/Sticker.cs
+++ b/src/Discord.Net.Rest/API/Common/Sticker.cs
@@ -11,7 +11,7 @@ namespace Discord.API
         [JsonProperty("name")]
         public string Name { get; set; }
         [JsonProperty("description")]
-        public string Desription { get; set; }
+        public string Description { get; set; }
         [JsonProperty("tags")]
         public Optional<string> Tags { get; set; }
         [JsonProperty("type")]

--- a/src/Discord.Net.Rest/API/Common/StickerItem.cs
+++ b/src/Discord.Net.Rest/API/Common/StickerItem.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {

--- a/src/Discord.Net.Rest/API/Common/StickerPack.cs
+++ b/src/Discord.Net.Rest/API/Common/StickerPack.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {

--- a/src/Discord.Net.Rest/API/Common/ThreadMember.cs
+++ b/src/Discord.Net.Rest/API/Common/ThreadMember.cs
@@ -1,9 +1,5 @@
 using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {
@@ -18,7 +14,7 @@ namespace Discord.API
         [JsonProperty("join_timestamp")]
         public DateTimeOffset JoinTimestamp { get; set; }
 
-        [JsonProperty("presense")]
+        [JsonProperty("presence")]
         public Optional<Presence> Presence { get; set; }
 
         [JsonProperty("member")]

--- a/src/Discord.Net.Rest/API/Common/ThreadMetadata.cs
+++ b/src/Discord.Net.Rest/API/Common/ThreadMetadata.cs
@@ -1,9 +1,5 @@
 using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API
 {

--- a/src/Discord.Net.Rest/API/Rest/CreateApplicationCommandParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateApplicationCommandParams.cs
@@ -1,10 +1,4 @@
-using Discord.API;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API.Rest
 {
@@ -30,7 +24,7 @@ namespace Discord.API.Rest
         {
             Name = name;
             Description = description;
-            Options = Optional.Create<ApplicationCommandOption[]>(options);
+            Options = Optional.Create(options);
             Type = type;
         }
     }

--- a/src/Discord.Net.Rest/API/Rest/CreateStageInstanceParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateStageInstanceParams.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API.Rest
 {

--- a/src/Discord.Net.Rest/API/Rest/CreateStickerParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/CreateStickerParams.cs
@@ -1,12 +1,6 @@
 using Discord.Net.Rest;
-using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord.API.Rest
 {
     internal class CreateStickerParams
@@ -30,7 +24,7 @@ namespace Discord.API.Rest
 
             if (File is FileStream fileStream)
                 contentType = $"image/{Path.GetExtension(fileStream.Name)}";
-            else if(FileName != null)
+            else if (FileName != null)
                 contentType = $"image/{Path.GetExtension(FileName)}";
 
             d["file"] = new MultipartFile(File, FileName ?? "image", contentType.Replace(".", ""));

--- a/src/Discord.Net.Rest/API/Rest/ModifyApplicationCommandParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyApplicationCommandParams.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API.Rest
 {

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildApplicationCommandPermissions.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildApplicationCommandPermissions.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API.Rest
 {

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildApplicationCommandPermissionsParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildApplicationCommandPermissionsParams.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API.Rest
 {

--- a/src/Discord.Net.Rest/API/Rest/ModifyInteractionResponseParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyInteractionResponseParams.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API.Rest
 {
@@ -19,7 +14,7 @@ namespace Discord.API.Rest
         public Optional<AllowedMentions> AllowedMentions { get; set; }
 
         [JsonProperty("components")]
-        public Optional<API.ActionRowComponent[]> Components { get; set; }
+        public Optional<ActionRowComponent[]> Components { get; set; }
 
         [JsonProperty("flags")]
         public Optional<MessageFlags?> Flags { get; set; }

--- a/src/Discord.Net.Rest/API/Rest/ModifyStageInstanceParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyStageInstanceParams.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API.Rest
 {

--- a/src/Discord.Net.Rest/API/Rest/ModifyStageInstanceParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyStageInstanceParams.cs
@@ -4,7 +4,6 @@ namespace Discord.API.Rest
 {
     internal class ModifyStageInstanceParams
     {
-
         [JsonProperty("topic")]
         public Optional<string> Topic { get; set; }
 

--- a/src/Discord.Net.Rest/API/Rest/ModifyStickerParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyStickerParams.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API.Rest
 {

--- a/src/Discord.Net.Rest/API/Rest/ModifyThreadParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyThreadParams.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Discord;
 using Newtonsoft.Json;
 
 namespace Discord.API.Rest

--- a/src/Discord.Net.Rest/API/Rest/StartThreadParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/StartThreadParams.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API.Rest
 {

--- a/src/Discord.Net.Rest/ClientHelper.cs
+++ b/src/Discord.Net.Rest/ClientHelper.cs
@@ -194,17 +194,17 @@ namespace Discord.Rest
             };
         }
 
-        public static async Task<IReadOnlyCollection<RestGlobalCommand>> GetGlobalApplicationCommands(BaseDiscordClient client,
+        public static async Task<IReadOnlyCollection<RestGlobalCommand>> GetGlobalApplicationCommandsAsync(BaseDiscordClient client,
             RequestOptions options = null)
         {
             var response = await client.ApiClient.GetGlobalApplicationCommandsAsync(options).ConfigureAwait(false);
 
             if (!response.Any())
-                return new RestGlobalCommand[0];
+                return Array.Empty<RestGlobalCommand>();
 
             return response.Select(x => RestGlobalCommand.Create(client, x)).ToArray();
         }
-        public static async Task<RestGlobalCommand> GetGlobalApplicationCommand(BaseDiscordClient client, ulong id,
+        public static async Task<RestGlobalCommand> GetGlobalApplicationCommandAsync(BaseDiscordClient client, ulong id,
             RequestOptions options = null)
         {
             var model = await client.ApiClient.GetGlobalApplicationCommandAsync(id, options);
@@ -212,55 +212,55 @@ namespace Discord.Rest
             return model != null ? RestGlobalCommand.Create(client, model) : null;
         }
 
-        public static async Task<IReadOnlyCollection<RestGuildCommand>> GetGuildApplicationCommands(BaseDiscordClient client, ulong guildId,
+        public static async Task<IReadOnlyCollection<RestGuildCommand>> GetGuildApplicationCommandsAsync(BaseDiscordClient client, ulong guildId,
             RequestOptions options = null)
         {
             var response = await client.ApiClient.GetGuildApplicationCommandsAsync(guildId, options).ConfigureAwait(false);
 
             if (!response.Any())
-                return new RestGuildCommand[0].ToImmutableArray();
+                return ImmutableArray.Create<RestGuildCommand>();
 
             return response.Select(x => RestGuildCommand.Create(client, x, guildId)).ToImmutableArray();
         }
-        public static async Task<RestGuildCommand> GetGuildApplicationCommand(BaseDiscordClient client, ulong id, ulong guildId,
+        public static async Task<RestGuildCommand> GetGuildApplicationCommandAsync(BaseDiscordClient client, ulong id, ulong guildId,
             RequestOptions options = null)
         {
             var model = await client.ApiClient.GetGuildApplicationCommandAsync(guildId, id, options);
 
             return model != null ? RestGuildCommand.Create(client, model, guildId) : null;
         }
-        public static async Task<RestGuildCommand> CreateGuildApplicationCommand(BaseDiscordClient client, ulong guildId, ApplicationCommandProperties properties,
+        public static async Task<RestGuildCommand> CreateGuildApplicationCommandAsync(BaseDiscordClient client, ulong guildId, ApplicationCommandProperties properties,
             RequestOptions options = null)
         {
-            var model = await InteractionHelper.CreateGuildCommand(client, guildId, properties, options);
+            var model = await InteractionHelper.CreateGuildCommandAsync(client, guildId, properties, options);
 
             return RestGuildCommand.Create(client, model, guildId);
         }
-        public static async Task<RestGlobalCommand> CreateGlobalApplicationCommand(BaseDiscordClient client, ApplicationCommandProperties properties,
+        public static async Task<RestGlobalCommand> CreateGlobalApplicationCommandAsync(BaseDiscordClient client, ApplicationCommandProperties properties,
             RequestOptions options = null)
         {
-            var model = await InteractionHelper.CreateGlobalCommand(client, properties, options);
+            var model = await InteractionHelper.CreateGlobalCommandAsync(client, properties, options);
 
             return RestGlobalCommand.Create(client, model);
         }
-        public static async Task<IReadOnlyCollection<RestGlobalCommand>> BulkOverwriteGlobalApplicationCommand(BaseDiscordClient client, ApplicationCommandProperties[] properties,
+        public static async Task<IReadOnlyCollection<RestGlobalCommand>> BulkOverwriteGlobalApplicationCommandAsync(BaseDiscordClient client, ApplicationCommandProperties[] properties,
             RequestOptions options = null)
         {
-            var models = await InteractionHelper.BulkOverwriteGlobalCommands(client, properties, options);
+            var models = await InteractionHelper.BulkOverwriteGlobalCommandsAsync(client, properties, options);
 
             return models.Select(x => RestGlobalCommand.Create(client, x)).ToImmutableArray();
         }
-        public static async Task<IReadOnlyCollection<RestGuildCommand>> BulkOverwriteGuildApplicationCommand(BaseDiscordClient client, ulong guildId,
+        public static async Task<IReadOnlyCollection<RestGuildCommand>> BulkOverwriteGuildApplicationCommandAsync(BaseDiscordClient client, ulong guildId,
             ApplicationCommandProperties[] properties, RequestOptions options = null)
         {
-            var models = await InteractionHelper.BulkOverwriteGuildCommands(client, guildId, properties, options);
+            var models = await InteractionHelper.BulkOverwriteGuildCommandsAsync(client, guildId, properties, options);
 
             return models.Select(x => RestGuildCommand.Create(client, x, guildId)).ToImmutableArray();
         }
 
         public static Task AddRoleAsync(BaseDiscordClient client, ulong guildId, ulong userId, ulong roleId, RequestOptions options = null)
             => client.ApiClient.AddRoleAsync(guildId, userId, roleId, options);
-        
+
         public static Task RemoveRoleAsync(BaseDiscordClient client, ulong guildId, ulong userId, ulong roleId, RequestOptions options = null)
             => client.ApiClient.RemoveRoleAsync(guildId, userId, roleId, options);
         #endregion

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -609,7 +609,6 @@ namespace Discord.API
         #region Stage
         public async Task<StageInstance> CreateStageInstanceAsync(CreateStageInstanceParams args, RequestOptions options = null)
         {
-
             options = RequestOptions.CreateOrClone(options);
 
             var bucket = new BucketIds();

--- a/src/Discord.Net.Rest/DiscordRestApiClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestApiClient.cs
@@ -534,7 +534,7 @@ namespace Discord.API
 
             var bucket = new BucketIds(channelId: channelId);
 
-            return await SendAsync<ChannelThreads>("GET", () => $"channels/{channelId}/threads/active", bucket);
+            return await SendAsync<ChannelThreads>("GET", () => $"channels/{channelId}/threads/active", bucket, options: options);
         }
 
         public async Task<ChannelThreads> GetPublicArchivedThreadsAsync(ulong channelId, DateTimeOffset? before = null, int? limit = null, RequestOptions options = null)

--- a/src/Discord.Net.Rest/DiscordRestClient.cs
+++ b/src/Discord.Net.Rest/DiscordRestClient.cs
@@ -110,17 +110,17 @@ namespace Discord.Rest
             => ClientHelper.GetWebhookAsync(this, id, options);
 
         public Task<RestGlobalCommand> CreateGlobalCommand(ApplicationCommandProperties properties, RequestOptions options = null)
-            => ClientHelper.CreateGlobalApplicationCommand(this, properties, options);
+            => ClientHelper.CreateGlobalApplicationCommandAsync(this, properties, options);
         public Task<RestGuildCommand> CreateGuildCommand(ApplicationCommandProperties properties, ulong guildId, RequestOptions options = null)
-            => ClientHelper.CreateGuildApplicationCommand(this, guildId, properties, options);
+            => ClientHelper.CreateGuildApplicationCommandAsync(this, guildId, properties, options);
         public Task<IReadOnlyCollection<RestGlobalCommand>> GetGlobalApplicationCommands(RequestOptions options = null)
-            => ClientHelper.GetGlobalApplicationCommands(this, options);
+            => ClientHelper.GetGlobalApplicationCommandsAsync(this, options);
         public Task<IReadOnlyCollection<RestGuildCommand>> GetGuildApplicationCommands(ulong guildId, RequestOptions options = null)
-            => ClientHelper.GetGuildApplicationCommands(this, guildId, options);
+            => ClientHelper.GetGuildApplicationCommandsAsync(this, guildId, options);
         public Task<IReadOnlyCollection<RestGlobalCommand>> BulkOverwriteGlobalCommands(ApplicationCommandProperties[] commandProperties, RequestOptions options = null)
-            => ClientHelper.BulkOverwriteGlobalApplicationCommand(this, commandProperties, options);
+            => ClientHelper.BulkOverwriteGlobalApplicationCommandAsync(this, commandProperties, options);
         public Task<IReadOnlyCollection<RestGuildCommand>> BulkOverwriteGuildCommands(ApplicationCommandProperties[] commandProperties, ulong guildId, RequestOptions options = null)
-            => ClientHelper.BulkOverwriteGuildApplicationCommand(this, guildId, commandProperties, options);
+            => ClientHelper.BulkOverwriteGuildApplicationCommandAsync(this, guildId, commandProperties, options);
         public Task<IReadOnlyCollection<GuildApplicationCommandPermission>> BatchEditGuildCommandPermissions(ulong guildId, IDictionary<ulong, ApplicationCommandPermission[]> permissions, RequestOptions options = null)
             => InteractionHelper.BatchEditGuildCommandPermissionsAsync(this, guildId, permissions, options);
         public Task DeleteAllGlobalCommandsAsync(RequestOptions options = null)
@@ -231,7 +231,7 @@ namespace Discord.Rest
             => await GetGlobalApplicationCommands(options).ConfigureAwait(false);
         /// <inheritdoc />
         async Task<IApplicationCommand> IDiscordClient.GetGlobalApplicationCommandAsync(ulong id, RequestOptions options)
-            => await ClientHelper.GetGlobalApplicationCommand(this, id, options).ConfigureAwait(false);
+            => await ClientHelper.GetGlobalApplicationCommandAsync(this, id, options).ConfigureAwait(false);
         #endregion
     }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/StageInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/StageInfo.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Discord.Rest
 {
     /// <summary>
@@ -28,9 +22,9 @@ namespace Discord.Rest
 
         internal StageInfo(IUser user, StagePrivacyLevel? level, string topic)
         {
-            this.Topic = topic;
-            this.PrivacyLevel = level;
-            this.User = user;
+            Topic = topic;
+            PrivacyLevel = level;
+            User = user;
         }
     }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/StageInstanceCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/StageInstanceCreateAuditLogData.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 using Model = Discord.API.AuditLog;
 using EntryModel = Discord.API.AuditLogEntry;

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/StageInstanceCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/StageInstanceCreateAuditLogData.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-
 using Model = Discord.API.AuditLog;
 using EntryModel = Discord.API.AuditLogEntry;
 

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/StageInstanceDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/StageInstanceDeleteAuditLogData.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 using Model = Discord.API.AuditLog;
 using EntryModel = Discord.API.AuditLogEntry;

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/StageInstanceDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/StageInstanceDeleteAuditLogData.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-
 using Model = Discord.API.AuditLog;
 using EntryModel = Discord.API.AuditLogEntry;
 

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/StageInstanceUpdatedAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/StageInstanceUpdatedAuditLogData.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Model = Discord.API.AuditLog;
 using EntryModel = Discord.API.AuditLogEntry;
 

--- a/src/Discord.Net.Rest/Entities/Channels/RestStageChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestStageChannel.cs
@@ -23,10 +23,7 @@ namespace Discord.Rest
         /// <inheritdoc/>
         public bool Live { get; private set; }
         internal RestStageChannel(BaseDiscordClient discord, IGuild guild, ulong id)
-            : base(discord, guild, id)
-        {
-
-        }
+            : base(discord, guild, id) { }
 
         internal new static RestStageChannel Create(BaseDiscordClient discord, IGuild guild, Model model)
         {

--- a/src/Discord.Net.Rest/Entities/Channels/RestStageChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestStageChannel.cs
@@ -1,10 +1,8 @@
+using Discord.API;
+using Discord.API.Rest;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Model = Discord.API.Channel;
-using StageInstance = Discord.API.StageInstance;
 
 namespace Discord.Rest
 {
@@ -30,7 +28,7 @@ namespace Discord.Rest
 
         }
 
-        internal static new RestStageChannel Create(BaseDiscordClient discord, IGuild guild, Model model)
+        internal new static RestStageChannel Create(BaseDiscordClient discord, IGuild guild, Model model)
         {
             var entity = new RestStageChannel(discord, guild, model.Id);
             entity.Update(model);
@@ -40,7 +38,7 @@ namespace Discord.Rest
         internal void Update(StageInstance model, bool isLive = false)
         {
             Live = isLive;
-            if(isLive)
+            if (isLive)
             {
                 Topic = model.Topic;
                 PrivacyLevel = model.PrivacyLevel;
@@ -65,7 +63,7 @@ namespace Discord.Rest
         /// <inheritdoc/>
         public async Task StartStageAsync(string topic, StagePrivacyLevel privacyLevel = StagePrivacyLevel.GuildOnly, RequestOptions options = null)
         {
-            var args = new API.Rest.CreateStageInstanceParams()
+            var args = new CreateStageInstanceParams
             {
                 ChannelId = Id,
                 PrivacyLevel = privacyLevel,
@@ -82,7 +80,7 @@ namespace Discord.Rest
         {
             await Discord.ApiClient.DeleteStageInstanceAsync(Id, options);
 
-            Update(null, false);
+            Update(null);
         }
 
         /// <inheritdoc/>
@@ -98,7 +96,7 @@ namespace Discord.Rest
         /// <inheritdoc/>
         public Task RequestToSpeakAsync(RequestOptions options = null)
         {
-            var args = new API.Rest.ModifyVoiceStateParams()
+            var args = new ModifyVoiceStateParams
             {
                 ChannelId = Id,
                 RequestToSpeakTimestamp = DateTimeOffset.UtcNow
@@ -109,7 +107,7 @@ namespace Discord.Rest
         /// <inheritdoc/>
         public Task BecomeSpeakerAsync(RequestOptions options = null)
         {
-            var args = new API.Rest.ModifyVoiceStateParams()
+            var args = new ModifyVoiceStateParams
             {
                 ChannelId = Id,
                 Suppressed = false
@@ -120,7 +118,7 @@ namespace Discord.Rest
         /// <inheritdoc/>
         public Task StopSpeakingAsync(RequestOptions options = null)
         {
-            var args = new API.Rest.ModifyVoiceStateParams()
+            var args = new ModifyVoiceStateParams
             {
                 ChannelId = Id,
                 Suppressed = true
@@ -131,7 +129,7 @@ namespace Discord.Rest
         /// <inheritdoc/>
         public Task MoveToSpeakerAsync(IGuildUser user, RequestOptions options = null)
         {
-            var args = new API.Rest.ModifyVoiceStateParams()
+            var args = new ModifyVoiceStateParams
             {
                 ChannelId = Id,
                 Suppressed = false
@@ -143,7 +141,7 @@ namespace Discord.Rest
         /// <inheritdoc/>
         public Task RemoveFromSpeakerAsync(IGuildUser user, RequestOptions options = null)
         {
-            var args = new API.Rest.ModifyVoiceStateParams()
+            var args = new ModifyVoiceStateParams
             {
                 ChannelId = Id,
                 Suppressed = true

--- a/src/Discord.Net.Rest/Entities/Channels/RestThreadChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestThreadChannel.cs
@@ -40,10 +40,7 @@ namespace Discord.Rest
         public ulong ParentChannelId { get; private set; }
 
         internal RestThreadChannel(BaseDiscordClient discord, IGuild guild, ulong id)
-            : base(discord, guild, id)
-        {
-
-        }
+            : base(discord, guild, id) { }
 
         internal new static RestThreadChannel Create(BaseDiscordClient discord, IGuild guild, Model model)
         {
@@ -64,7 +61,6 @@ namespace Discord.Rest
                 AutoArchiveDuration = model.ThreadMetadata.Value.AutoArchiveDuration;
                 ArchiveTimestamp = model.ThreadMetadata.Value.ArchiveTimestamp;
                 Locked = model.ThreadMetadata.Value.Locked.GetValueOrDefault(false);
-
             }
 
             MemberCount = model.MemberCount.GetValueOrDefault(0);
@@ -207,7 +203,6 @@ namespace Discord.Rest
         /// </remarks>
         public override IReadOnlyCollection<Overwrite> PermissionOverwrites
             => throw new NotSupportedException("This method is not supported in threads.");
-
 
         /// <inheritdoc/>
         public Task JoinAsync(RequestOptions options = null)

--- a/src/Discord.Net.Rest/Entities/Channels/RestThreadChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestThreadChannel.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Model = Discord.API.Channel;
 
@@ -66,7 +64,7 @@ namespace Discord.Rest
                 AutoArchiveDuration = model.ThreadMetadata.Value.AutoArchiveDuration;
                 ArchiveTimestamp = model.ThreadMetadata.Value.ArchiveTimestamp;
                 Locked = model.ThreadMetadata.Value.Locked.GetValueOrDefault(false);
-                
+
             }
 
             MemberCount = model.MemberCount.GetValueOrDefault(0);
@@ -110,107 +108,107 @@ namespace Discord.Rest
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task AddPermissionOverwriteAsync(IRole role, OverwritePermissions permissions, RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task AddPermissionOverwriteAsync(IUser user, OverwritePermissions permissions, RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task<IInviteMetadata> CreateInviteAsync(int? maxAge = 86400, int? maxUses = null, bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task<IInviteMetadata> CreateInviteToApplicationAsync(ulong applicationId, int? maxAge, int? maxUses = null, bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task<IInviteMetadata> CreateInviteToStreamAsync(IUser user, int? maxAge, int? maxUses = null, bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task<RestWebhook> CreateWebhookAsync(string name, Stream avatar = null, RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task<ICategoryChannel> GetCategoryAsync(RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task<IReadOnlyCollection<IInviteMetadata>> GetInvitesAsync(RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override OverwritePermissions? GetPermissionOverwrite(IRole role)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override OverwritePermissions? GetPermissionOverwrite(IUser user)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task<RestWebhook> GetWebhookAsync(ulong id, RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task<IReadOnlyCollection<RestWebhook>> GetWebhooksAsync(RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task RemovePermissionOverwriteAsync(IRole role, RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task RemovePermissionOverwriteAsync(IUser user, RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override IReadOnlyCollection<Overwrite> PermissionOverwrites
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
-        
+
         /// <inheritdoc/>
         public Task JoinAsync(RequestOptions options = null)
             => Discord.ApiClient.JoinThreadAsync(Id, options);

--- a/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ThreadHelper.cs
@@ -1,8 +1,6 @@
 using Discord.API.Rest;
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Model = Discord.API.Channel;
 
@@ -14,22 +12,22 @@ namespace Discord.Rest
             ThreadArchiveDuration autoArchiveDuration = ThreadArchiveDuration.OneDay, IMessage message = null, RequestOptions options = null)
         {
             if (autoArchiveDuration == ThreadArchiveDuration.OneWeek && !channel.Guild.Features.Contains("SEVEN_DAY_THREAD_ARCHIVE"))
-                throw new ArgumentException($"The guild {channel.Guild.Name} does not have the SEVEN_DAY_THREAD_ARCHIVE feature!");
+                throw new ArgumentException($"The guild {channel.Guild.Name} does not have the SEVEN_DAY_THREAD_ARCHIVE feature!", nameof(autoArchiveDuration));
 
             if (autoArchiveDuration == ThreadArchiveDuration.ThreeDays && !channel.Guild.Features.Contains("THREE_DAY_THREAD_ARCHIVE"))
-                throw new ArgumentException($"The guild {channel.Guild.Name} does not have the THREE_DAY_THREAD_ARCHIVE feature!");
+                throw new ArgumentException($"The guild {channel.Guild.Name} does not have the THREE_DAY_THREAD_ARCHIVE feature!", nameof(autoArchiveDuration));
 
             if (type == ThreadType.PrivateThread && !channel.Guild.Features.Contains("PRIVATE_THREADS"))
-                throw new ArgumentException($"The guild {channel.Guild.Name} does not have the PRIVATE_THREADS feature!");
+                throw new ArgumentException($"The guild {channel.Guild.Name} does not have the PRIVATE_THREADS feature!", nameof(type));
 
-            var args = new StartThreadParams()
+            var args = new StartThreadParams
             {
                 Name = name,
                 Duration = autoArchiveDuration,
                 Type = type
             };
 
-            Model model = null;
+            Model model;
 
             if (message != null)
                 model = await client.ApiClient.StartThreadAsync(channel.Id, message.Id, args, options).ConfigureAwait(false);
@@ -45,7 +43,7 @@ namespace Discord.Rest
         {
             var args = new TextChannelProperties();
             func(args);
-            var apiArgs = new API.Rest.ModifyThreadParams
+            var apiArgs = new ModifyThreadParams
             {
                 Name = args.Name,
                 Archived = args.Archived,
@@ -63,7 +61,7 @@ namespace Discord.Rest
             return users.Select(x => RestThreadUser.Create(client, channel.Guild, x, channel)).ToArray();
         }
 
-        public static async Task<RestThreadUser> GetUserAsync(ulong userdId, IThreadChannel channel, BaseDiscordClient client, RequestOptions options = null)
-            => (await GetUsersAsync(channel, client, options).ConfigureAwait(false)).FirstOrDefault(x => x.Id == userdId);
+        public static async Task<RestThreadUser> GetUserAsync(ulong userId, IThreadChannel channel, BaseDiscordClient client, RequestOptions options = null)
+            => (await GetUsersAsync(channel, client, options).ConfigureAwait(false)).FirstOrDefault(x => x.Id == userId);
     }
 }

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -922,7 +922,7 @@ namespace Discord.Rest
         ///     of application commands found within the guild.
         /// </returns>
         public async Task<IReadOnlyCollection<RestGuildCommand>> GetApplicationCommandsAsync (RequestOptions options = null)
-            => await ClientHelper.GetGuildApplicationCommands(Discord, Id, options).ConfigureAwait(false);
+            => await ClientHelper.GetGuildApplicationCommandsAsync(Discord, Id, options).ConfigureAwait(false);
         /// <summary>
         ///     Gets an application command within this guild with the specified id.
         /// </summary>
@@ -933,7 +933,7 @@ namespace Discord.Rest
         ///     if found, otherwise <see langword="null"/>.
         /// </returns>
         public async Task<RestGuildCommand> GetApplicationCommandAsync(ulong id, RequestOptions options = null)
-            => await ClientHelper.GetGuildApplicationCommand(Discord, id, Id, options);
+            => await ClientHelper.GetGuildApplicationCommandAsync(Discord, id, Id, options);
         /// <summary>
         ///     Creates an application command within this guild.
         /// </summary>
@@ -944,7 +944,7 @@ namespace Discord.Rest
         /// </returns>
         public async Task<RestGuildCommand> CreateApplicationCommandAsync(ApplicationCommandProperties properties, RequestOptions options = null)
         {
-            var model = await InteractionHelper.CreateGuildCommand(Discord, Id, properties, options);
+            var model = await InteractionHelper.CreateGuildCommandAsync(Discord, Id, properties, options);
 
             return RestGuildCommand.Create(Discord, model, Id);
         }
@@ -959,7 +959,7 @@ namespace Discord.Rest
         public async Task<IReadOnlyCollection<RestGuildCommand>> BulkOverwriteApplicationCommandsAsync(ApplicationCommandProperties[] properties,
             RequestOptions options = null)
         {
-            var models = await InteractionHelper.BulkOverwriteGuildCommands(Discord, Id, properties, options);
+            var models = await InteractionHelper.BulkOverwriteGuildCommandsAsync(Discord, Id, properties, options);
 
             return models.Select(x => RestGuildCommand.Create(Discord, x, Id)).ToImmutableArray();
         }

--- a/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
@@ -4,6 +4,7 @@ using Discord.Net;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace Discord.Rest
@@ -13,15 +14,15 @@ namespace Discord.Rest
         #region InteractionHelper
         public static Task DeleteAllGuildCommandsAsync(BaseDiscordClient client, ulong guildId, RequestOptions options = null)
         {
-            return client.ApiClient.BulkOverwriteGuildApplicationCommandsAsync(guildId, new CreateApplicationCommandParams[0], options);
+            return client.ApiClient.BulkOverwriteGuildApplicationCommandsAsync(guildId, Array.Empty<CreateApplicationCommandParams>(), options);
         }
 
         public static Task DeleteAllGlobalCommandsAsync(BaseDiscordClient client, RequestOptions options = null)
         {
-            return client.ApiClient.BulkOverwriteGlobalApplicationCommandsAsync(new CreateApplicationCommandParams[0], options);
+            return client.ApiClient.BulkOverwriteGlobalApplicationCommandsAsync(Array.Empty<CreateApplicationCommandParams>(), options);
         }
 
-        public static Task SendInteractionResponse(BaseDiscordClient client, InteractionResponse response,
+        public static Task SendInteractionResponseAsync(BaseDiscordClient client, InteractionResponse response,
             ulong interactionId, string interactionToken, RequestOptions options = null)
         {
             return client.ApiClient.CreateInteractionResponseAsync(response, interactionId, interactionToken, options);
@@ -39,7 +40,7 @@ namespace Discord.Rest
         {
             var model = await client.ApiClient.CreateInteractionFollowupMessageAsync(args, token, options).ConfigureAwait(false);
 
-            RestFollowupMessage entity = RestFollowupMessage.Create(client, model, token, channel);
+            var entity = RestFollowupMessage.Create(client, model, token, channel);
             return entity;
         }
         #endregion
@@ -53,19 +54,19 @@ namespace Discord.Rest
 
             return RestGlobalCommand.Create(client, model);
         }
-        public static Task<ApplicationCommand> CreateGlobalCommand<TArg>(BaseDiscordClient client,
+        public static Task<ApplicationCommand> CreateGlobalCommandAsync<TArg>(BaseDiscordClient client,
             Action<TArg> func, RequestOptions options = null) where TArg : ApplicationCommandProperties
         {
             var args = Activator.CreateInstance(typeof(TArg));
             func((TArg)args);
-            return CreateGlobalCommand(client, (TArg)args, options);
+            return CreateGlobalCommandAsync(client, (TArg)args, options);
         }
-        public static async Task<ApplicationCommand> CreateGlobalCommand(BaseDiscordClient client,
+        public static async Task<ApplicationCommand> CreateGlobalCommandAsync(BaseDiscordClient client,
             ApplicationCommandProperties arg, RequestOptions options = null)
         {
             Preconditions.NotNullOrEmpty(arg.Name, nameof(arg.Name));
 
-            var model = new CreateApplicationCommandParams()
+            var model = new CreateApplicationCommandParams
             {
                 Name = arg.Name.Value,
                 Type = arg.Type,
@@ -81,25 +82,25 @@ namespace Discord.Rest
                 model.Description = slashProps.Description.Value;
 
                 model.Options = slashProps.Options.IsSpecified
-                    ? slashProps.Options.Value.Select(x => new Discord.API.ApplicationCommandOption(x)).ToArray()
-                    : Optional<Discord.API.ApplicationCommandOption[]>.Unspecified;
+                    ? slashProps.Options.Value.Select(x => new ApplicationCommandOption(x)).ToArray()
+                    : Optional<ApplicationCommandOption[]>.Unspecified;
             }
 
             return await client.ApiClient.CreateGlobalApplicationCommandAsync(model, options).ConfigureAwait(false);
         }
 
-        public static async Task<ApplicationCommand[]> BulkOverwriteGlobalCommands(BaseDiscordClient client,
+        public static async Task<ApplicationCommand[]> BulkOverwriteGlobalCommandsAsync(BaseDiscordClient client,
             ApplicationCommandProperties[] args, RequestOptions options = null)
         {
             Preconditions.NotNull(args, nameof(args));
 
-            List<CreateApplicationCommandParams> models = new List<CreateApplicationCommandParams>();
+            var models = new List<CreateApplicationCommandParams>();
 
             foreach (var arg in args)
             {
                 Preconditions.NotNullOrEmpty(arg.Name, nameof(arg.Name));
 
-                var model = new CreateApplicationCommandParams()
+                var model = new CreateApplicationCommandParams
                 {
                     Name = arg.Name.Value,
                     Type = arg.Type,
@@ -115,28 +116,28 @@ namespace Discord.Rest
                     model.Description = slashProps.Description.Value;
 
                     model.Options = slashProps.Options.IsSpecified
-                        ? slashProps.Options.Value.Select(x => new Discord.API.ApplicationCommandOption(x)).ToArray()
-                        : Optional<Discord.API.ApplicationCommandOption[]>.Unspecified;
+                        ? slashProps.Options.Value.Select(x => new ApplicationCommandOption(x)).ToArray()
+                        : Optional<ApplicationCommandOption[]>.Unspecified;
                 }
 
                 models.Add(model);
             }
 
-           return await client.ApiClient.BulkOverwriteGlobalApplicationCommandsAsync(models.ToArray(), options).ConfigureAwait(false);
+            return await client.ApiClient.BulkOverwriteGlobalApplicationCommandsAsync(models.ToArray(), options).ConfigureAwait(false);
         }
 
-        public static async Task<IReadOnlyCollection<ApplicationCommand>> BulkOverwriteGuildCommands(BaseDiscordClient client, ulong guildId,
+        public static async Task<IReadOnlyCollection<ApplicationCommand>> BulkOverwriteGuildCommandsAsync(BaseDiscordClient client, ulong guildId,
             ApplicationCommandProperties[] args, RequestOptions options = null)
         {
             Preconditions.NotNull(args, nameof(args));
 
-            List<CreateApplicationCommandParams> models = new List<CreateApplicationCommandParams>();
+            var models = new List<CreateApplicationCommandParams>();
 
             foreach (var arg in args)
             {
                 Preconditions.NotNullOrEmpty(arg.Name, nameof(arg.Name));
 
-                var model = new CreateApplicationCommandParams()
+                var model = new CreateApplicationCommandParams
                 {
                     Name = arg.Name.Value,
                     Type = arg.Type,
@@ -152,8 +153,8 @@ namespace Discord.Rest
                     model.Description = slashProps.Description.Value;
 
                     model.Options = slashProps.Options.IsSpecified
-                        ? slashProps.Options.Value.Select(x => new Discord.API.ApplicationCommandOption(x)).ToArray()
-                        : Optional<Discord.API.ApplicationCommandOption[]>.Unspecified;
+                        ? slashProps.Options.Value.Select(x => new ApplicationCommandOption(x)).ToArray()
+                        : Optional<ApplicationCommandOption[]>.Unspecified;
                 }
 
                 models.Add(model);
@@ -180,15 +181,15 @@ namespace Discord.Rest
             }
         }
 
-        public static Task<ApplicationCommand> ModifyGlobalCommand<TArg>(BaseDiscordClient client, IApplicationCommand command,
+        public static Task<ApplicationCommand> ModifyGlobalCommandAsync<TArg>(BaseDiscordClient client, IApplicationCommand command,
             Action<TArg> func, RequestOptions options = null) where TArg : ApplicationCommandProperties
         {
             var arg = GetApplicationCommandProperties<TArg>(command);
             func(arg);
-            return ModifyGlobalCommand(client, command, arg, options);
+            return ModifyGlobalCommandAsync(client, command, arg, options);
         }
 
-        public static async Task<ApplicationCommand> ModifyGlobalCommand(BaseDiscordClient client, IApplicationCommand command,
+        public static async Task<ApplicationCommand> ModifyGlobalCommandAsync(BaseDiscordClient client, IApplicationCommand command,
            ApplicationCommandProperties args, RequestOptions options = null)
         {
             if (args.Name.IsSpecified)
@@ -197,7 +198,7 @@ namespace Discord.Rest
                 Preconditions.AtLeast(args.Name.Value.Length, 1, nameof(args.Name));
             }
 
-            var model = new Discord.API.Rest.ModifyApplicationCommandParams()
+            var model = new ModifyApplicationCommandParams
             {
                 Name = args.Name,
                 DefaultPermission = args.DefaultPermission.IsSpecified
@@ -205,7 +206,7 @@ namespace Discord.Rest
                         : Optional<bool>.Unspecified
             };
 
-            if(args is SlashCommandProperties slashProps)
+            if (args is SlashCommandProperties slashProps)
             {
                 if (slashProps.Description.IsSpecified)
                 {
@@ -222,15 +223,15 @@ namespace Discord.Rest
                 model.Description = slashProps.Description;
 
                 model.Options = slashProps.Options.IsSpecified
-                    ? slashProps.Options.Value.Select(x => new Discord.API.ApplicationCommandOption(x)).ToArray()
-                    : Optional<Discord.API.ApplicationCommandOption[]>.Unspecified;
+                    ? slashProps.Options.Value.Select(x => new ApplicationCommandOption(x)).ToArray()
+                    : Optional<ApplicationCommandOption[]>.Unspecified;
             }
 
             return await client.ApiClient.ModifyGlobalApplicationCommandAsync(model, command.Id, options).ConfigureAwait(false);
         }
 
 
-        public static async Task DeleteGlobalCommand(BaseDiscordClient client, IApplicationCommand command, RequestOptions options = null)
+        public static async Task DeleteGlobalCommandAsync(BaseDiscordClient client, IApplicationCommand command, RequestOptions options = null)
         {
             Preconditions.NotNull(command, nameof(command));
             Preconditions.NotEqual(command.Id, 0, nameof(command.Id));
@@ -240,18 +241,18 @@ namespace Discord.Rest
         #endregion
 
         #region Guild Commands
-        public static Task<ApplicationCommand> CreateGuildCommand<TArg>(BaseDiscordClient client, ulong guildId,
+        public static Task<ApplicationCommand> CreateGuildCommandAsync<TArg>(BaseDiscordClient client, ulong guildId,
             Action<TArg> func, RequestOptions options) where TArg : ApplicationCommandProperties
         {
             var args = Activator.CreateInstance(typeof(TArg));
             func((TArg)args);
-            return CreateGuildCommand(client, guildId, (TArg)args, options);
+            return CreateGuildCommandAsync(client, guildId, (TArg)args, options);
         }
 
-        public static async Task<ApplicationCommand> CreateGuildCommand(BaseDiscordClient client, ulong guildId,
+        public static async Task<ApplicationCommand> CreateGuildCommandAsync(BaseDiscordClient client, ulong guildId,
            ApplicationCommandProperties arg, RequestOptions options = null)
         {
-            var model = new CreateApplicationCommandParams()
+            var model = new CreateApplicationCommandParams
             {
                 Name = arg.Name.Value,
                 Type = arg.Type,
@@ -267,25 +268,25 @@ namespace Discord.Rest
                 model.Description = slashProps.Description.Value;
 
                 model.Options = slashProps.Options.IsSpecified
-                    ? slashProps.Options.Value.Select(x => new Discord.API.ApplicationCommandOption(x)).ToArray()
-                    : Optional<Discord.API.ApplicationCommandOption[]>.Unspecified;
+                    ? slashProps.Options.Value.Select(x => new ApplicationCommandOption(x)).ToArray()
+                    : Optional<ApplicationCommandOption[]>.Unspecified;
             }
 
             return await client.ApiClient.CreateGuildApplicationCommandAsync(model, guildId, options).ConfigureAwait(false);
         }
 
-        public static Task<ApplicationCommand> ModifyGuildCommand<TArg>(BaseDiscordClient client, IApplicationCommand command, ulong guildId,
+        public static Task<ApplicationCommand> ModifyGuildCommandAsync<TArg>(BaseDiscordClient client, IApplicationCommand command, ulong guildId,
             Action<TArg> func, RequestOptions options = null) where TArg : ApplicationCommandProperties
         {
             var arg = GetApplicationCommandProperties<TArg>(command);
             func(arg);
-            return ModifyGuildCommand(client, command, guildId, arg, options);
+            return ModifyGuildCommandAsync(client, command, guildId, arg, options);
         }
 
-        public static async Task<ApplicationCommand> ModifyGuildCommand(BaseDiscordClient client, IApplicationCommand command, ulong guildId,
+        public static async Task<ApplicationCommand> ModifyGuildCommandAsync(BaseDiscordClient client, IApplicationCommand command, ulong guildId,
             ApplicationCommandProperties arg, RequestOptions options = null)
         {
-            var model = new ModifyApplicationCommandParams()
+            var model = new ModifyApplicationCommandParams
             {
                 Name = arg.Name,
                 DefaultPermission = arg.DefaultPermission.IsSpecified
@@ -300,14 +301,14 @@ namespace Discord.Rest
                 model.Description = slashProps.Description.Value;
 
                 model.Options = slashProps.Options.IsSpecified
-                    ? slashProps.Options.Value.Select(x => new Discord.API.ApplicationCommandOption(x)).ToArray()
-                    : Optional<Discord.API.ApplicationCommandOption[]>.Unspecified;
+                    ? slashProps.Options.Value.Select(x => new ApplicationCommandOption(x)).ToArray()
+                    : Optional<ApplicationCommandOption[]>.Unspecified;
             }
 
             return await client.ApiClient.ModifyGuildApplicationCommandAsync(model, guildId, command.Id, options).ConfigureAwait(false);
         }
 
-        public static async Task DeleteGuildCommand(BaseDiscordClient client, ulong guildId, IApplicationCommand command, RequestOptions options = null)
+        public static async Task DeleteGuildCommandAsync(BaseDiscordClient client, ulong guildId, IApplicationCommand command, RequestOptions options = null)
         {
             Preconditions.NotNull(command, nameof(command));
             Preconditions.NotEqual(command.Id, 0, nameof(command.Id));
@@ -315,21 +316,16 @@ namespace Discord.Rest
             await client.ApiClient.DeleteGuildApplicationCommandAsync(guildId, command.Id, options).ConfigureAwait(false);
         }
 
-        public static Task DeleteUnknownApplicationCommand(BaseDiscordClient client, ulong? guildId, IApplicationCommand command, RequestOptions options = null)
+        public static Task DeleteUnknownApplicationCommandAsync(BaseDiscordClient client, ulong? guildId, IApplicationCommand command, RequestOptions options = null)
         {
-            if (guildId.HasValue)
-            {
-                return DeleteGuildCommand(client, guildId.Value, command, options);
-            }
-            else
-            {
-                return DeleteGlobalCommand(client, command, options);
-            }
+            return guildId.HasValue
+                ? DeleteGuildCommandAsync(client, guildId.Value, command, options)
+                : DeleteGlobalCommandAsync(client, command, options);
         }
         #endregion
 
         #region Responses
-        public static async Task<Discord.API.Message> ModifyFollowupMessage(BaseDiscordClient client, RestFollowupMessage message, Action<MessageProperties> func,
+        public static async Task<Message> ModifyFollowupMessageAsync(BaseDiscordClient client, RestFollowupMessage message, Action<MessageProperties> func,
             RequestOptions options = null)
         {
             var args = new MessageProperties();
@@ -359,21 +355,21 @@ namespace Discord.Rest
 
             Preconditions.AtMost(apiEmbeds?.Count ?? 0, 10, nameof(args.Embeds), "A max of 10 embeds are allowed.");
 
-            var apiArgs = new API.Rest.ModifyInteractionResponseParams
+            var apiArgs = new ModifyInteractionResponseParams
             {
                 Content = args.Content,
                 Embeds = apiEmbeds?.ToArray() ?? Optional<API.Embed[]>.Unspecified,
                 AllowedMentions = args.AllowedMentions.IsSpecified ? args.AllowedMentions.Value.ToModel() : Optional<API.AllowedMentions>.Unspecified,
-                Components = args.Components.IsSpecified ? args.Components.Value?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() : Optional<API.ActionRowComponent[]>.Unspecified,
+                Components = args.Components.IsSpecified ? args.Components.Value?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() : Optional<API.ActionRowComponent[]>.Unspecified
             };
 
             return await client.ApiClient.ModifyInteractionFollowupMessageAsync(apiArgs, message.Id, message.Token, options).ConfigureAwait(false);
         }
 
-        public static async Task DeleteFollowupMessage(BaseDiscordClient client, RestFollowupMessage message, RequestOptions options = null)
+        public static async Task DeleteFollowupMessageAsync(BaseDiscordClient client, RestFollowupMessage message, RequestOptions options = null)
             => await client.ApiClient.DeleteInteractionFollowupMessageAsync(message.Id, message.Token, options);
 
-        public static async Task<Message> ModifyInteractionResponse(BaseDiscordClient client, string token, Action<MessageProperties> func,
+        public static async Task<Message> ModifyInteractionResponseAsync(BaseDiscordClient client, string token, Action<MessageProperties> func,
            RequestOptions options = null)
         {
             var args = new MessageProperties();
@@ -415,25 +411,24 @@ namespace Discord.Rest
             return await client.ApiClient.ModifyInteractionResponseAsync(apiArgs, token, options).ConfigureAwait(false);
         }
 
-        public static async Task DeletedInteractionResponse(BaseDiscordClient client, RestInteractionMessage message, RequestOptions options = null)
+        public static async Task DeleteInteractionResponseAsync(BaseDiscordClient client, RestInteractionMessage message, RequestOptions options = null)
             => await client.ApiClient.DeleteInteractionFollowupMessageAsync(message.Id, message.Token, options);
 
         public static Task SendAutocompleteResult(BaseDiscordClient client, IEnumerable<AutocompleteResult> result, ulong interactionId,
             string interactionToken, RequestOptions options)
         {
-            if (result == null)
-                result = new AutocompleteResult[0];
+            result ??= Array.Empty<AutocompleteResult>();
 
             Preconditions.AtMost(result.Count(), 20, nameof(result), "A maximum of 20 choices are allowed!");
 
-            var apiArgs = new InteractionResponse()
+            var apiArgs = new InteractionResponse
             {
                 Type = InteractionResponseType.ApplicationCommandAutocompleteResult,
-                Data = new InteractionCallbackData()
+                Data = new InteractionCallbackData
                 {
                     Choices = result.Any()
-                        ? result.Select(x => new API.ApplicationCommandOptionChoice() { Name = x.Name, Value = x.Value }).ToArray()
-                        : new ApplicationCommandOptionChoice[0]
+                        ? result.Select(x => new ApplicationCommandOptionChoice { Name = x.Name, Value = x.Value }).ToArray()
+                        : Array.Empty<ApplicationCommandOptionChoice>()
                 }
             };
 
@@ -448,7 +443,7 @@ namespace Discord.Rest
             var models = await client.ApiClient.GetGuildApplicationCommandPermissionsAsync(guildId, options);
             return models.Select(x =>
                 new GuildApplicationCommandPermission(x.Id, x.ApplicationId, guildId, x.Permissions.Select(
-                    y => new Discord.ApplicationCommandPermission(y.Id, y.Type, y.Permission))
+                    y => new ApplicationCommandPermission(y.Id, y.Type, y.Permission))
                 .ToArray())
             ).ToArray();
         }
@@ -464,7 +459,7 @@ namespace Discord.Rest
             }
             catch (HttpException x)
             {
-                if (x.HttpCode == System.Net.HttpStatusCode.NotFound)
+                if (x.HttpCode == HttpStatusCode.NotFound)
                     return null;
                 throw;
             }
@@ -477,11 +472,11 @@ namespace Discord.Rest
             Preconditions.AtMost(args.Length, 10, nameof(args));
             Preconditions.AtLeast(args.Length, 0, nameof(args));
 
-            List<ApplicationCommandPermissions> permissionsList = new List<ApplicationCommandPermissions>();
+            var permissionsList = new List<ApplicationCommandPermissions>();
 
             foreach (var arg in args)
             {
-                var permissions = new ApplicationCommandPermissions()
+                var permissions = new ApplicationCommandPermissions
                 {
                     Id = arg.TargetId,
                     Permission = arg.Permission,
@@ -491,7 +486,7 @@ namespace Discord.Rest
                 permissionsList.Add(permissions);
             }
 
-            ModifyGuildApplicationCommandPermissionsParams model = new ModifyGuildApplicationCommandPermissionsParams()
+            var model = new ModifyGuildApplicationCommandPermissionsParams
             {
                 Permissions = permissionsList.ToArray()
             };
@@ -508,16 +503,16 @@ namespace Discord.Rest
             Preconditions.NotNull(args, nameof(args));
             Preconditions.NotEqual(args.Count, 0, nameof(args));
 
-            List<ModifyGuildApplicationCommandPermissions> models = new List<ModifyGuildApplicationCommandPermissions>();
+            var models = new List<ModifyGuildApplicationCommandPermissions>();
 
             foreach (var arg in args)
             {
                 Preconditions.AtMost(arg.Value.Length, 10, nameof(args));
 
-                var model = new ModifyGuildApplicationCommandPermissions()
+                var model = new ModifyGuildApplicationCommandPermissions
                 {
                     Id = arg.Key,
-                    Permissions = arg.Value.Select(x => new ApplicationCommandPermissions()
+                    Permissions = arg.Value.Select(x => new ApplicationCommandPermissions
                     {
                         Id = x.TargetId,
                         Permission = x.Permission,

--- a/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
@@ -414,7 +414,7 @@ namespace Discord.Rest
         public static async Task DeleteInteractionResponseAsync(BaseDiscordClient client, RestInteractionMessage message, RequestOptions options = null)
             => await client.ApiClient.DeleteInteractionFollowupMessageAsync(message.Id, message.Token, options);
 
-        public static Task SendAutocompleteResult(BaseDiscordClient client, IEnumerable<AutocompleteResult> result, ulong interactionId,
+        public static Task SendAutocompleteResultAsync(BaseDiscordClient client, IEnumerable<AutocompleteResult> result, ulong interactionId,
             string interactionToken, RequestOptions options)
         {
             result ??= Array.Empty<AutocompleteResult>();

--- a/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
@@ -51,7 +51,6 @@ namespace Discord.Rest
         {
             var model = await client.ApiClient.GetGlobalApplicationCommandAsync(id, options).ConfigureAwait(false);
 
-
             return RestGlobalCommand.Create(client, model);
         }
         public static Task<ApplicationCommand> CreateGlobalCommandAsync<TArg>(BaseDiscordClient client,
@@ -230,7 +229,6 @@ namespace Discord.Rest
             return await client.ApiClient.ModifyGlobalApplicationCommandAsync(model, command.Id, options).ConfigureAwait(false);
         }
 
-
         public static async Task DeleteGlobalCommandAsync(BaseDiscordClient client, IApplicationCommand command, RequestOptions options = null)
         {
             Preconditions.NotNull(command, nameof(command));
@@ -365,10 +363,8 @@ namespace Discord.Rest
 
             return await client.ApiClient.ModifyInteractionFollowupMessageAsync(apiArgs, message.Id, message.Token, options).ConfigureAwait(false);
         }
-
         public static async Task DeleteFollowupMessageAsync(BaseDiscordClient client, RestFollowupMessage message, RequestOptions options = null)
             => await client.ApiClient.DeleteInteractionFollowupMessageAsync(message.Id, message.Token, options);
-
         public static async Task<Message> ModifyInteractionResponseAsync(BaseDiscordClient client, string token, Action<MessageProperties> func,
            RequestOptions options = null)
         {

--- a/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommand.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Model = Discord.API.ApplicationCommand;
 
@@ -45,14 +44,9 @@ namespace Discord.Rest
 
         internal static RestApplicationCommand Create(BaseDiscordClient client, Model model, ulong? guildId)
         {
-            if (guildId.HasValue)
-            {
-                return RestGuildCommand.Create(client, model, guildId.Value);
-            }
-            else
-            {
-                return RestGlobalCommand.Create(client, model);
-            }
+            return guildId.HasValue
+                ? RestGuildCommand.Create(client, model, guildId.Value)
+                : RestGlobalCommand.Create(client, model);
         }
 
         internal virtual void Update(Model model)
@@ -64,7 +58,7 @@ namespace Discord.Rest
             IsDefaultPermission = model.DefaultPermissions.GetValueOrDefault(true);
 
             Options = model.Options.IsSpecified
-                ? model.Options.Value.Select(x => RestApplicationCommandOption.Create(x)).ToImmutableArray()
+                ? model.Options.Value.Select(RestApplicationCommandOption.Create).ToImmutableArray()
                 : ImmutableArray.Create<RestApplicationCommandOption>();
         }
 
@@ -76,7 +70,7 @@ namespace Discord.Rest
         {
             return ModifyAsync<ApplicationCommandProperties>(func, options);
         }
-        
+
         /// <inheritdoc/>
         public abstract Task ModifyAsync<TArg>(Action<TArg> func, RequestOptions options = null)
             where TArg : ApplicationCommandProperties;

--- a/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommand.cs
@@ -37,10 +37,7 @@ namespace Discord.Rest
             => SnowflakeUtils.FromSnowflake(Id);
 
         internal RestApplicationCommand(BaseDiscordClient client, ulong id)
-            : base(client, id)
-        {
-
-        }
+            : base(client, id) { }
 
         internal static RestApplicationCommand Create(BaseDiscordClient client, Model model, ulong? guildId)
         {

--- a/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommandChoice.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommandChoice.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Model = Discord.API.ApplicationCommandOptionChoice;
 
 namespace Discord.Rest

--- a/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommandOption.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommandOption.cs
@@ -1,9 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Model = Discord.API.ApplicationCommandOption;
 
 namespace Discord.Rest
@@ -66,7 +63,7 @@ namespace Discord.Rest
                 IsRequired = model.Required.Value;
 
             Options = model.Options.IsSpecified
-                ? model.Options.Value.Select(x => Create(x)).ToImmutableArray()
+                ? model.Options.Value.Select(Create).ToImmutableArray()
                 : ImmutableArray.Create<RestApplicationCommandOption>();
 
             Choices = model.Choices.IsSpecified

--- a/src/Discord.Net.Rest/Entities/Interactions/RestGlobalCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestGlobalCommand.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Model = Discord.API.ApplicationCommand;
 
@@ -27,7 +24,7 @@ namespace Discord.Rest
 
         /// <inheritdoc/>
         public override async Task DeleteAsync(RequestOptions options = null)
-            => await InteractionHelper.DeleteGlobalCommand(Discord, this).ConfigureAwait(false);
+            => await InteractionHelper.DeleteGlobalCommandAsync(Discord, this).ConfigureAwait(false);
 
         /// <summary>
         ///     Modifies this <see cref="RestApplicationCommand"/>.
@@ -39,7 +36,7 @@ namespace Discord.Rest
         /// </returns>
         public override async Task ModifyAsync<TArg>(Action<TArg> func, RequestOptions options = null)
         {
-            var cmd = await InteractionHelper.ModifyGlobalCommand<TArg>(Discord, this, func, options).ConfigureAwait(false);
+            var cmd = await InteractionHelper.ModifyGlobalCommandAsync(Discord, this, func, options).ConfigureAwait(false);
             Update(cmd);
         }
     }

--- a/src/Discord.Net.Rest/Entities/Interactions/RestGlobalCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestGlobalCommand.cs
@@ -10,10 +10,7 @@ namespace Discord.Rest
     public class RestGlobalCommand : RestApplicationCommand
     {
         internal RestGlobalCommand(BaseDiscordClient client, ulong id)
-            : base(client, id)
-        {
-
-        }
+            : base(client, id) { }
 
         internal static RestGlobalCommand Create(BaseDiscordClient client, Model model)
         {

--- a/src/Discord.Net.Rest/Entities/Interactions/RestGuildCommand.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestGuildCommand.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Model = Discord.API.ApplicationCommand;
 
@@ -32,7 +29,7 @@ namespace Discord.Rest
 
         /// <inheritdoc/>
         public override async Task DeleteAsync(RequestOptions options = null)
-            => await InteractionHelper.DeleteGuildCommand(Discord, GuildId, this).ConfigureAwait(false);
+            => await InteractionHelper.DeleteGuildCommandAsync(Discord, GuildId, this).ConfigureAwait(false);
 
         /// <summary>
         ///     Modifies this <see cref="RestApplicationCommand"/>.
@@ -44,7 +41,7 @@ namespace Discord.Rest
         /// </returns>
         public override async Task ModifyAsync<TArg>(Action<TArg> func, RequestOptions options = null)
         {
-            var model = await InteractionHelper.ModifyGuildCommand<TArg>(Discord, this, GuildId, func, options).ConfigureAwait(false);
+            var model = await InteractionHelper.ModifyGuildCommandAsync(Discord, this, GuildId, func, options).ConfigureAwait(false);
             Update(model);
         }
 

--- a/src/Discord.Net.Rest/Entities/Messages/CustomSticker.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/CustomSticker.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Model = Discord.API.Sticker;
 

--- a/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/MessageHelper.cs
@@ -84,7 +84,7 @@ namespace Discord.Rest
             {
                 Content = args.Content,
                 Embeds = apiEmbeds?.ToArray() ?? Optional<API.Embed[]>.Unspecified,
-                Components = args.Components.IsSpecified ? args.Components.Value?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? new API.ActionRowComponent[0] : Optional<API.ActionRowComponent[]>.Unspecified,
+                Components = args.Components.IsSpecified ? args.Components.Value?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? Array.Empty<API.ActionRowComponent>() : Optional<API.ActionRowComponent[]>.Unspecified,
                 Flags = args.Flags,
                 AllowedMentions = args.AllowedMentions.IsSpecified ? args.AllowedMentions.Value.ToModel() : Optional<API.AllowedMentions>.Unspecified,
             };
@@ -151,7 +151,7 @@ namespace Discord.Rest
                 Embeds = apiEmbeds?.ToArray() ?? Optional<API.Embed[]>.Unspecified,
                 Flags = args.Flags.IsSpecified ? args.Flags.Value : Optional.Create<MessageFlags?>(),
                 AllowedMentions = args.AllowedMentions.IsSpecified ? args.AllowedMentions.Value.ToModel() : Optional.Create<API.AllowedMentions>(),
-                Components = args.Components.IsSpecified ? args.Components.Value?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? new API.ActionRowComponent[0] : Optional<API.ActionRowComponent[]>.Unspecified,
+                Components = args.Components.IsSpecified ? args.Components.Value?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? Array.Empty<API.ActionRowComponent>() : Optional<API.ActionRowComponent[]>.Unspecified,
             };
             return await client.ApiClient.ModifyMessageAsync(channelId, msgId, apiArgs, options).ConfigureAwait(false);
         }

--- a/src/Discord.Net.Rest/Entities/Messages/RestFollowupMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestFollowupMessage.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Model = Discord.API.Message;
 
@@ -39,7 +36,7 @@ namespace Discord.Rest
         /// </summary>
         /// <returns>A task that represents the asynchronous delete operation.</returns>
         public Task DeleteAsync()
-            => InteractionHelper.DeleteFollowupMessage(Discord, this);
+            => InteractionHelper.DeleteFollowupMessageAsync(Discord, this);
 
         /// <summary>
         ///     Modifies this interaction followup message.
@@ -65,12 +62,12 @@ namespace Discord.Rest
         {
             try
             {
-                var model = await InteractionHelper.ModifyFollowupMessage(Discord, this, func, options).ConfigureAwait(false);
+                var model = await InteractionHelper.ModifyFollowupMessageAsync(Discord, this, func, options).ConfigureAwait(false);
                 Update(model);
             }
-            catch (Discord.Net.HttpException x)
+            catch (Net.HttpException x)
             {
-                if(x.HttpCode == System.Net.HttpStatusCode.NotFound)
+                if (x.HttpCode == System.Net.HttpStatusCode.NotFound)
                 {
                     throw new InvalidOperationException("The token of this message has expired!", x);
                 }

--- a/src/Discord.Net.Rest/Entities/Messages/RestFollowupMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestFollowupMessage.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using Model = Discord.API.Message;
 
-
 namespace Discord.Rest
 {
     /// <summary>

--- a/src/Discord.Net.Rest/Entities/Messages/RestInteractionMessage.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/RestInteractionMessage.cs
@@ -35,7 +35,7 @@ namespace Discord.Rest
         /// </summary>
         /// <returns>A task that represents the asynchronous delete operation.</returns>
         public Task DeleteAsync()
-            => InteractionHelper.DeletedInteractionResponse(Discord, this);
+            => InteractionHelper.DeleteInteractionResponseAsync(Discord, this);
 
         /// <summary>
         ///     Modifies this interaction response
@@ -61,10 +61,10 @@ namespace Discord.Rest
         {
             try
             {
-                var model = await InteractionHelper.ModifyInteractionResponse(Discord, Token, func, options).ConfigureAwait(false);
+                var model = await InteractionHelper.ModifyInteractionResponseAsync(Discord, Token, func, options).ConfigureAwait(false);
                 Update(model);
             }
-            catch (Discord.Net.HttpException x)
+            catch (Net.HttpException x)
             {
                 if (x.HttpCode == System.Net.HttpStatusCode.NotFound)
                 {

--- a/src/Discord.Net.Rest/Entities/Messages/Sticker.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/Sticker.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -43,8 +44,8 @@ namespace Discord.Rest
         {
             PackId = model.PackId;
             Name = model.Name;
-            Description = model.Desription;
-            Tags = model.Tags.IsSpecified ? model.Tags.Value.Split(',').Select(x => x.Trim()).ToArray() : new string[0];
+            Description = model.Description;
+            Tags = model.Tags.IsSpecified ? model.Tags.Value.Split(',').Select(x => x.Trim()).ToArray() : Array.Empty<string>();
             Type = model.Type;
             SortOrder = model.SortValue;
             IsAvailable = model.Available;

--- a/src/Discord.Net.Rest/Entities/Messages/StickerItem.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/StickerItem.cs
@@ -27,7 +27,6 @@ namespace Discord.Rest
         /// <returns>
         ///     A task representing the download operation, the result of the task is a sticker object.
         /// </returns>
-
         public async Task<Sticker> ResolveStickerAsync()
         {
             var model = await Discord.ApiClient.GetStickerAsync(Id);

--- a/src/Discord.Net.Rest/Entities/Messages/StickerItem.cs
+++ b/src/Discord.Net.Rest/Entities/Messages/StickerItem.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Model = Discord.API.StickerItem;
 
@@ -36,10 +32,9 @@ namespace Discord.Rest
         {
             var model = await Discord.ApiClient.GetStickerAsync(Id);
 
-            if (model.GuildId.IsSpecified)
-                return CustomSticker.Create(Discord, model, model.GuildId.Value, model.User.IsSpecified ? model.User.Value.Id : null);
-            else
-                return Sticker.Create(Discord, model);
+            return model.GuildId.IsSpecified
+                ? CustomSticker.Create(Discord, model, model.GuildId.Value, model.User.IsSpecified ? model.User.Value.Id : null)
+                : Sticker.Create(Discord, model);
         }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Users/RestThreadUser.cs
+++ b/src/Discord.Net.Rest/Entities/Users/RestThreadUser.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Model = Discord.API.ThreadMember;
 

--- a/src/Discord.Net.Rest/Net/Converters/InteractionConverter.cs
+++ b/src/Discord.Net.Rest/Net/Converters/InteractionConverter.cs
@@ -1,10 +1,6 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.Net.Converters
 {

--- a/src/Discord.Net.Rest/Net/Converters/MessageComponentConverter.cs
+++ b/src/Discord.Net.Rest/Net/Converters/MessageComponentConverter.cs
@@ -1,10 +1,6 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.Net.Converters
 {

--- a/src/Discord.Net.WebSocket/API/Gateway/ApplicationCommandCreatedUpdatedEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/ApplicationCommandCreatedUpdatedEvent.cs
@@ -1,13 +1,8 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API.Gateway
 {
-    internal class ApplicationCommandCreatedUpdatedEvent : API.ApplicationCommand
+    internal class ApplicationCommandCreatedUpdatedEvent : ApplicationCommand
     {
         [JsonProperty("guild_id")]
         public Optional<ulong> GuildId { get; set; }

--- a/src/Discord.Net.WebSocket/API/Gateway/GuildStickerUpdateEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/GuildStickerUpdateEvent.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API.Gateway
 {

--- a/src/Discord.Net.WebSocket/API/Gateway/ThreadListSyncEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/ThreadListSyncEvent.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API.Gateway
 {

--- a/src/Discord.Net.WebSocket/API/Gateway/ThreadMembersUpdate.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/ThreadMembersUpdate.cs
@@ -1,9 +1,4 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.API.Gateway
 {

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -434,7 +434,7 @@ namespace Discord.WebSocket
 
         public async Task<SocketApplicationCommand> CreateGlobalApplicationCommandAsync(ApplicationCommandProperties properties, RequestOptions options = null)
         {
-            var model = await InteractionHelper.CreateGlobalCommand(this, properties, options).ConfigureAwait(false);
+            var model = await InteractionHelper.CreateGlobalCommandAsync(this, properties, options).ConfigureAwait(false);
 
             var entity = State.GetOrAddCommand(model.Id, (id) => SocketApplicationCommand.Create(this, model));
 
@@ -446,7 +446,7 @@ namespace Discord.WebSocket
         public async Task<IReadOnlyCollection<SocketApplicationCommand>> BulkOverwriteGlobalApplicationCommandsAsync(
             ApplicationCommandProperties[] properties, RequestOptions options = null)
         {
-            var models = await InteractionHelper.BulkOverwriteGlobalCommands(this, properties, options);
+            var models = await InteractionHelper.BulkOverwriteGlobalCommandsAsync(this, properties, options);
 
             var entities = models.Select(x => SocketApplicationCommand.Create(this, x));
 

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketStageChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketStageChannel.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Model = Discord.API.Channel;
 using StageInstance = Discord.API.StageInstance;
@@ -25,8 +24,7 @@ namespace Discord.WebSocket
         public bool? DiscoverableDisabled { get; private set; }
 
         /// <inheritdoc/>
-        public bool Live { get; private set; } = false;
-
+        public bool Live { get; private set; }
         /// <summary>
         ///     Returns <see langword="true"/> if the current user is a speaker within the stage, otherwise <see langword="false"/>.
         /// </summary>
@@ -55,11 +53,6 @@ namespace Discord.WebSocket
             return entity;
         }
 
-        internal override void Update(ClientState state, Model model)
-        {
-            base.Update(state, model);
-        }
-
         internal void Update(StageInstance model, bool isLive = false)
         {
             Live = isLive;
@@ -80,11 +73,11 @@ namespace Discord.WebSocket
         /// <inheritdoc/>
         public async Task StartStageAsync(string topic, StagePrivacyLevel privacyLevel = StagePrivacyLevel.GuildOnly, RequestOptions options = null)
         {
-            var args = new API.Rest.CreateStageInstanceParams()
+            var args = new API.Rest.CreateStageInstanceParams
             {
                 ChannelId = Id,
                 Topic = topic,
-                PrivacyLevel = privacyLevel,
+                PrivacyLevel = privacyLevel
             };
 
             var model = await Discord.ApiClient.CreateStageInstanceAsync(args, options).ConfigureAwait(false);
@@ -105,13 +98,13 @@ namespace Discord.WebSocket
         {
             await Discord.ApiClient.DeleteStageInstanceAsync(Id, options);
 
-            Update(null, false);
+            Update(null);
         }
 
         /// <inheritdoc/>
         public Task RequestToSpeakAsync(RequestOptions options = null)
         {
-            var args = new API.Rest.ModifyVoiceStateParams()
+            var args = new API.Rest.ModifyVoiceStateParams
             {
                 ChannelId = Id,
                 RequestToSpeakTimestamp = DateTimeOffset.UtcNow
@@ -122,7 +115,7 @@ namespace Discord.WebSocket
         /// <inheritdoc/>
         public Task BecomeSpeakerAsync(RequestOptions options = null)
         {
-            var args = new API.Rest.ModifyVoiceStateParams()
+            var args = new API.Rest.ModifyVoiceStateParams
             {
                 ChannelId = Id,
                 Suppressed = false
@@ -133,7 +126,7 @@ namespace Discord.WebSocket
         /// <inheritdoc/>
         public Task StopSpeakingAsync(RequestOptions options = null)
         {
-            var args = new API.Rest.ModifyVoiceStateParams()
+            var args = new API.Rest.ModifyVoiceStateParams
             {
                 ChannelId = Id,
                 Suppressed = true
@@ -144,7 +137,7 @@ namespace Discord.WebSocket
         /// <inheritdoc/>
         public Task MoveToSpeakerAsync(IGuildUser user, RequestOptions options = null)
         {
-            var args = new API.Rest.ModifyVoiceStateParams()
+            var args = new API.Rest.ModifyVoiceStateParams
             {
                 ChannelId = Id,
                 Suppressed = false
@@ -156,7 +149,7 @@ namespace Discord.WebSocket
         /// <inheritdoc/>
         public Task RemoveFromSpeakerAsync(IGuildUser user, RequestOptions options = null)
         {
-            var args = new API.Rest.ModifyVoiceStateParams()
+            var args = new API.Rest.ModifyVoiceStateParams
             {
                 ChannelId = Id,
                 Suppressed = true

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketStageChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketStageChannel.cs
@@ -39,12 +39,8 @@ namespace Discord.WebSocket
 
         internal new SocketStageChannel Clone() => MemberwiseClone() as SocketStageChannel;
 
-
         internal SocketStageChannel(DiscordSocketClient discord, ulong id, SocketGuild guild)
-            : base(discord, id, guild)
-        {
-
-        }
+            : base(discord, id, guild) { }
 
         internal new static SocketStageChannel Create(SocketGuild guild, ClientState state, Model model)
         {

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketThreadChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketThreadChannel.cs
@@ -5,11 +5,9 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Model = Discord.API.Channel;
 using ThreadMember = Discord.API.ThreadMember;
-using MemberUpdates = Discord.API.Gateway.ThreadMembersUpdated;
 using System.Collections.Concurrent;
 
 namespace Discord.WebSocket
@@ -73,13 +71,13 @@ namespace Discord.WebSocket
             _members.Values.ToImmutableArray();
 
 
-        private ConcurrentDictionary<ulong, SocketThreadUser> _members;
+        private readonly ConcurrentDictionary<ulong, SocketThreadUser> _members;
 
         private string DebuggerDisplay => $"{Name} ({Id}, Thread)";
 
-        private bool _usersDownloaded = false;
+        private bool _usersDownloaded;
 
-        private object _downloadLock = new object();
+        private readonly object _downloadLock = new object();
 
         internal SocketThreadChannel(DiscordSocketClient discord, SocketGuild guild, ulong id, SocketTextChannel parent)
             : base(discord, id, guild)
@@ -103,12 +101,12 @@ namespace Discord.WebSocket
             Type = (ThreadType)model.Type;
             MessageCount = model.MessageCount.GetValueOrDefault(-1);
             MemberCount = model.MemberCount.GetValueOrDefault(-1);
-            
+
             if (model.ThreadMetadata.IsSpecified)
             {
                 Archived = model.ThreadMetadata.Value.Archived;
                 ArchiveTimestamp = model.ThreadMetadata.Value.ArchiveTimestamp;
-                AutoArchiveDuration = (ThreadArchiveDuration)model.ThreadMetadata.Value.AutoArchiveDuration;
+                AutoArchiveDuration = model.ThreadMetadata.Value.AutoArchiveDuration;
                 Locked = model.ThreadMetadata.Value.Locked.GetValueOrDefault(false);
             }
 
@@ -178,7 +176,7 @@ namespace Discord.WebSocket
         ///     Downloads all users that have access to this thread.
         /// </summary>
         /// <param name="options">The options to be used when sending the request.</param>
-        /// <returns>A task representing the asyncronous download operation.</returns>
+        /// <returns>A task representing the asynchronous download operation.</returns>
         public async Task DownloadUsersAsync(RequestOptions options = null)
         {
             var users = await Discord.ApiClient.ListThreadMembersAsync(Id, options);
@@ -193,7 +191,7 @@ namespace Discord.WebSocket
                 }
             }
         }
-        
+
         internal new SocketThreadChannel Clone() => MemberwiseClone() as SocketThreadChannel;
 
         /// <inheritdoc/>
@@ -210,7 +208,7 @@ namespace Discord.WebSocket
         /// <param name="user">The <see cref="IGuildUser"/> to add.</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
-        ///     A task that represents the asynchronous operation of adding a member to a thread. 
+        ///     A task that represents the asynchronous operation of adding a member to a thread.
         /// </returns>
         public Task AddUserAsync(IGuildUser user, RequestOptions options = null)
             => Discord.ApiClient.AddThreadMemberAsync(Id, user.Id, options);
@@ -221,7 +219,7 @@ namespace Discord.WebSocket
         /// <param name="user">The <see cref="IGuildUser"/> to remove from this thread.</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
-        ///     A task that represents the asynchronous operation of removing a user from this thread. 
+        ///     A task that represents the asynchronous operation of removing a user from this thread.
         /// </returns>
         public Task RemoveUserAsync(IGuildUser user, RequestOptions options = null)
             => Discord.ApiClient.RemoveThreadMemberAsync(Id, user.Id, options);
@@ -232,49 +230,49 @@ namespace Discord.WebSocket
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task AddPermissionOverwriteAsync(IRole role, OverwritePermissions permissions, RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task AddPermissionOverwriteAsync(IUser user, OverwritePermissions permissions, RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task<IInviteMetadata> CreateInviteAsync(int? maxAge = 86400, int? maxUses = null, bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task<IInviteMetadata> CreateInviteToApplicationAsync(ulong applicationId, int? maxAge, int? maxUses = null, bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task<IInviteMetadata> CreateInviteToStreamAsync(IUser user, int? maxAge, int? maxUses = null, bool isTemporary = false, bool isUnique = false, RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task<RestWebhook> CreateWebhookAsync(string name, Stream avatar = null, RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task<IReadOnlyCollection<IInviteMetadata>> GetInvitesAsync(RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
@@ -295,14 +293,14 @@ namespace Discord.WebSocket
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task<RestWebhook> GetWebhookAsync(ulong id, RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task<IReadOnlyCollection<RestWebhook>> GetWebhooksAsync(RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
@@ -316,28 +314,28 @@ namespace Discord.WebSocket
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task RemovePermissionOverwriteAsync(IRole role, RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task RemovePermissionOverwriteAsync(IUser user, RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override IReadOnlyCollection<Overwrite> PermissionOverwrites
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         /// <inheritdoc/>
         /// <remarks>
         ///     <b>This method is not supported in threads.</b>
         /// </remarks>
         public override Task SyncPermissionsAsync(RequestOptions options = null)
-            => throw new NotImplementedException();
+            => throw new NotSupportedException("This method is not supported in threads.");
 
         string IChannel.Name => Name;
     }

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketThreadChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketThreadChannel.cs
@@ -70,7 +70,6 @@ namespace Discord.WebSocket
         public new IReadOnlyCollection<SocketThreadUser> Users =>
             _members.Values.ToImmutableArray();
 
-
         private readonly ConcurrentDictionary<ulong, SocketThreadUser> _members;
 
         private string DebuggerDisplay => $"{Name} ({Id}, Thread)";
@@ -171,7 +170,6 @@ namespace Discord.WebSocket
             return Users;
         }
 
-
         /// <summary>
         ///     Downloads all users that have access to this thread.
         /// </summary>
@@ -223,7 +221,6 @@ namespace Discord.WebSocket
         /// </returns>
         public Task RemoveUserAsync(IGuildUser user, RequestOptions options = null)
             => Discord.ApiClient.RemoveThreadMemberAsync(Id, user.Id, options);
-
 
         /// <inheritdoc/>
         /// <remarks>

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -906,7 +906,7 @@ namespace Discord.WebSocket
         /// </returns>
         public async Task<SocketApplicationCommand> CreateApplicationCommandAsync(ApplicationCommandProperties properties, RequestOptions options = null)
         {
-            var model = await InteractionHelper.CreateGuildCommand(Discord, Id, properties, options);
+            var model = await InteractionHelper.CreateGuildCommandAsync(Discord, Id, properties, options);
 
             var entity = Discord.State.GetOrAddCommand(model.Id, (id) => SocketApplicationCommand.Create(Discord, model));
 
@@ -926,7 +926,7 @@ namespace Discord.WebSocket
         public async Task<IReadOnlyCollection<SocketApplicationCommand>> BulkOverwriteApplicationCommandAsync(ApplicationCommandProperties[] properties,
             RequestOptions options = null)
         {
-            var models = await InteractionHelper.BulkOverwriteGuildCommands(Discord, Id, properties, options);
+            var models = await InteractionHelper.BulkOverwriteGuildCommandsAsync(Discord, Id, properties, options);
 
             var entities = models.Select(x => SocketApplicationCommand.Create(Discord, x));
 

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Context Menu Commands/Message Commands/SocketMessageCommand.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Context Menu Commands/Message Commands/SocketMessageCommand.cs
@@ -1,7 +1,3 @@
-using Discord.Rest;
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 using DataModel = Discord.API.ApplicationCommandInteractionData;
 using Model = Discord.API.Interaction;
 
@@ -31,7 +27,7 @@ namespace Discord.WebSocket
             Data = SocketMessageCommandData.Create(client, dataModel, model.Id, guildId);
         }
 
-        new internal static SocketInteraction Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
+        internal new static SocketInteraction Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
         {
             var entity = new SocketMessageCommand(client, model, channel);
             entity.Update(model);

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Context Menu Commands/Message Commands/SocketMessageCommand.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Context Menu Commands/Message Commands/SocketMessageCommand.cs
@@ -16,8 +16,8 @@ namespace Discord.WebSocket
         internal SocketMessageCommand(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
             : base(client, model, channel)
         {
-            var dataModel = model.Data.IsSpecified ?
-                (DataModel)model.Data.Value
+            var dataModel = model.Data.IsSpecified
+                ? (DataModel)model.Data.Value
                 : null;
 
             ulong? guildId = null;

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Context Menu Commands/User Commands/SocketUserCommand.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Context Menu Commands/User Commands/SocketUserCommand.cs
@@ -16,8 +16,8 @@ namespace Discord.WebSocket
         internal SocketUserCommand(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
             : base(client, model, channel)
         {
-            var dataModel = model.Data.IsSpecified ?
-                (DataModel)model.Data.Value
+            var dataModel = model.Data.IsSpecified
+                ? (DataModel)model.Data.Value
                 : null;
 
             ulong? guildId = null;

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Context Menu Commands/User Commands/SocketUserCommand.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Context Menu Commands/User Commands/SocketUserCommand.cs
@@ -1,7 +1,3 @@
-using Discord.Rest;
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 using DataModel = Discord.API.ApplicationCommandInteractionData;
 using Model = Discord.API.Interaction;
 
@@ -31,11 +27,11 @@ namespace Discord.WebSocket
             Data = SocketUserCommandData.Create(client, dataModel, model.Id, guildId);
         }
 
-        new internal static SocketInteraction Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
+        internal new static SocketInteraction Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
         {
             var entity = new SocketUserCommand(client, model, channel);
             entity.Update(model);
             return entity;
-        }        
+        }
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Message Components/SocketMessageComponent.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Message Components/SocketMessageComponent.cs
@@ -28,8 +28,8 @@ namespace Discord.WebSocket
         internal SocketMessageComponent(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
             : base(client, model.Id, channel)
         {
-            var dataModel = model.Data.IsSpecified ?
-                (DataModel)model.Data.Value
+            var dataModel = model.Data.IsSpecified
+                ? (DataModel)model.Data.Value
                 : null;
 
             Data = new SocketMessageComponentData(dataModel);
@@ -41,7 +41,6 @@ namespace Discord.WebSocket
             entity.Update(model);
             return entity;
         }
-
         internal override void Update(Model model)
         {
             base.Update(model);
@@ -69,7 +68,6 @@ namespace Discord.WebSocket
                 }
             }
         }
-
         /// <inheritdoc/>
         public override async Task RespondAsync(
             string text = null,
@@ -340,7 +338,6 @@ namespace Discord.WebSocket
             {
                 Type = InteractionResponseType.DeferredChannelMessageWithSource,
                 Data = ephemeral ? new API.InteractionCallbackData { Flags = MessageFlags.Ephemeral } : Optional<API.InteractionCallbackData>.Unspecified
-
             };
 
             return Discord.Rest.ApiClient.CreateInteractionResponseAsync(response, Id, Token, options);
@@ -353,7 +350,6 @@ namespace Discord.WebSocket
             {
                 Type = InteractionResponseType.DeferredUpdateMessage,
                 Data = ephemeral ? new API.InteractionCallbackData { Flags = MessageFlags.Ephemeral } : Optional<API.InteractionCallbackData>.Unspecified
-
             };
 
             return Discord.Rest.ApiClient.CreateInteractionResponseAsync(response, Id, Token, options);

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Message Components/SocketMessageComponent.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Message Components/SocketMessageComponent.cs
@@ -18,7 +18,7 @@ namespace Discord.WebSocket
         /// <summary>
         ///     The data received with this interaction, contains the button that was clicked.
         /// </summary>
-        new public SocketMessageComponentData Data { get; }
+        public new SocketMessageComponentData Data { get; }
 
         /// <summary>
         ///     The message that contained the trigger for this interaction.
@@ -35,7 +35,7 @@ namespace Discord.WebSocket
             Data = new SocketMessageComponentData(dataModel);
         }
 
-        new internal static SocketMessageComponent Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
+        internal new static SocketMessageComponent Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
         {
             var entity = new SocketMessageComponent(client, model, channel);
             entity.Update(model);
@@ -90,7 +90,7 @@ namespace Discord.WebSocket
 
             Preconditions.AtMost(allowedMentions?.RoleIds?.Count ?? 0, 100, nameof(allowedMentions.RoleIds), "A max of 100 role Ids are allowed.");
             Preconditions.AtMost(allowedMentions?.UserIds?.Count ?? 0, 100, nameof(allowedMentions.UserIds), "A max of 100 user Ids are allowed.");
-            Preconditions.AtMost(embeds?.Length ?? 0, 10, nameof(embeds), "A max of 10 embeds are allowed.");
+            Preconditions.AtMost(embeds.Length, 10, nameof(embeds), "A max of 10 embeds are allowed.");
 
             // check that user flag and user Id list are exclusive, same with role flag and role Id list
             if (allowedMentions != null && allowedMentions.AllowedTypes.HasValue)
@@ -115,7 +115,7 @@ namespace Discord.WebSocket
                 {
                     Content = text ?? Optional<string>.Unspecified,
                     AllowedMentions = allowedMentions?.ToModel(),
-                    Embeds = embeds?.Select(x => x.ToModel()).ToArray() ?? Optional<API.Embed[]>.Unspecified,
+                    Embeds = embeds.Select(x => x.ToModel()).ToArray(),
                     TTS = isTTS,
                     Components = component?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? Optional<API.ActionRowComponent[]>.Unspecified
                 }
@@ -124,7 +124,7 @@ namespace Discord.WebSocket
             if (ephemeral)
                 response.Data.Value.Flags = MessageFlags.Ephemeral;
 
-            await InteractionHelper.SendInteractionResponse(Discord, response, Id, Token, options);
+            await InteractionHelper.SendInteractionResponseAsync(Discord, response, Id, Token, options);
         }
 
         /// <summary>
@@ -197,13 +197,13 @@ namespace Discord.WebSocket
                     AllowedMentions = args.AllowedMentions.IsSpecified ? args.AllowedMentions.Value?.ToModel() : Optional<API.AllowedMentions>.Unspecified,
                     Embeds = apiEmbeds?.ToArray() ?? Optional<API.Embed[]>.Unspecified,
                     Components = args.Components.IsSpecified
-                        ? args.Components.Value?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? new API.ActionRowComponent[0]
+                        ? args.Components.Value?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? Array.Empty<API.ActionRowComponent>()
                         : Optional<API.ActionRowComponent[]>.Unspecified,
                     Flags = args.Flags.IsSpecified ? args.Flags.Value ?? Optional<MessageFlags>.Unspecified : Optional<MessageFlags>.Unspecified
                 }
             };
 
-            await InteractionHelper.SendInteractionResponse(Discord, response, Id, Token, options);
+            await InteractionHelper.SendInteractionResponseAsync(Discord, response, Id, Token, options);
         }
 
         /// <inheritdoc/>
@@ -226,15 +226,15 @@ namespace Discord.WebSocket
 
             Preconditions.AtMost(allowedMentions?.RoleIds?.Count ?? 0, 100, nameof(allowedMentions.RoleIds), "A max of 100 role Ids are allowed.");
             Preconditions.AtMost(allowedMentions?.UserIds?.Count ?? 0, 100, nameof(allowedMentions.UserIds), "A max of 100 user Ids are allowed.");
-            Preconditions.AtMost(embeds?.Length ?? 0, 10, nameof(embeds), "A max of 10 embeds are allowed.");
+            Preconditions.AtMost(embeds.Length, 10, nameof(embeds), "A max of 10 embeds are allowed.");
 
             var args = new API.Rest.CreateWebhookMessageParams
             {
                 Content = text,
                 AllowedMentions = allowedMentions?.ToModel() ?? Optional<API.AllowedMentions>.Unspecified,
                 IsTTS = isTTS,
-                Embeds = embeds?.Select(x => x.ToModel()).ToArray() ?? Optional<API.Embed[]>.Unspecified,
-                Components = component?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? Optional<API.ActionRowComponent[]>.Unspecified,
+                Embeds = embeds.Select(x => x.ToModel()).ToArray(),
+                Components = component?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? Optional<API.ActionRowComponent[]>.Unspecified
             };
 
             if (ephemeral)
@@ -265,7 +265,7 @@ namespace Discord.WebSocket
 
             Preconditions.AtMost(allowedMentions?.RoleIds?.Count ?? 0, 100, nameof(allowedMentions.RoleIds), "A max of 100 role Ids are allowed.");
             Preconditions.AtMost(allowedMentions?.UserIds?.Count ?? 0, 100, nameof(allowedMentions.UserIds), "A max of 100 user Ids are allowed.");
-            Preconditions.AtMost(embeds?.Length ?? 0, 10, nameof(embeds), "A max of 10 embeds are allowed.");
+            Preconditions.AtMost(embeds.Length, 10, nameof(embeds), "A max of 10 embeds are allowed.");
             Preconditions.NotNull(fileStream, nameof(fileStream), "File Stream must have data");
             Preconditions.NotNullOrWhitespace(fileName, nameof(fileName), "File Name must not be empty or null");
 
@@ -274,7 +274,7 @@ namespace Discord.WebSocket
                 Content = text,
                 AllowedMentions = allowedMentions?.ToModel() ?? Optional<API.AllowedMentions>.Unspecified,
                 IsTTS = isTTS,
-                Embeds = embeds?.Select(x => x.ToModel()).ToArray() ?? Optional<API.Embed[]>.Unspecified,
+                Embeds = embeds.Select(x => x.ToModel()).ToArray(),
                 Components = component?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? Optional<API.ActionRowComponent[]>.Unspecified,
                 File = fileStream is not null ? new MultipartFile(fileStream, fileName) : Optional<MultipartFile>.Unspecified
             };
@@ -307,7 +307,7 @@ namespace Discord.WebSocket
 
             Preconditions.AtMost(allowedMentions?.RoleIds?.Count ?? 0, 100, nameof(allowedMentions.RoleIds), "A max of 100 role Ids are allowed.");
             Preconditions.AtMost(allowedMentions?.UserIds?.Count ?? 0, 100, nameof(allowedMentions.UserIds), "A max of 100 user Ids are allowed.");
-            Preconditions.AtMost(embeds?.Length ?? 0, 10, nameof(embeds), "A max of 10 embeds are allowed.");
+            Preconditions.AtMost(embeds.Length, 10, nameof(embeds), "A max of 10 embeds are allowed.");
             Preconditions.NotNullOrWhitespace(filePath, nameof(filePath), "Path must exist");
 
             var args = new API.Rest.CreateWebhookMessageParams
@@ -315,7 +315,7 @@ namespace Discord.WebSocket
                 Content = text,
                 AllowedMentions = allowedMentions?.ToModel() ?? Optional<API.AllowedMentions>.Unspecified,
                 IsTTS = isTTS,
-                Embeds = embeds?.Select(x => x.ToModel()).ToArray() ?? Optional<API.Embed[]>.Unspecified,
+                Embeds = embeds.Select(x => x.ToModel()).ToArray(),
                 Components = component?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? Optional<API.ActionRowComponent[]>.Unspecified,
                 File = !string.IsNullOrEmpty(filePath) ? new MultipartFile(new MemoryStream(File.ReadAllBytes(filePath), false), fileName) : Optional<MultipartFile>.Unspecified
             };
@@ -336,10 +336,10 @@ namespace Discord.WebSocket
         /// </returns>
         public Task DeferLoadingAsync(bool ephemeral = false, RequestOptions options = null)
         {
-            var response = new API.InteractionResponse()
+            var response = new API.InteractionResponse
             {
                 Type = InteractionResponseType.DeferredChannelMessageWithSource,
-                Data = ephemeral ? new API.InteractionCallbackData() { Flags = MessageFlags.Ephemeral } : Optional<API.InteractionCallbackData>.Unspecified
+                Data = ephemeral ? new API.InteractionCallbackData { Flags = MessageFlags.Ephemeral } : Optional<API.InteractionCallbackData>.Unspecified
 
             };
 
@@ -349,10 +349,10 @@ namespace Discord.WebSocket
         /// <inheritdoc/>
         public override Task DeferAsync(bool ephemeral = false, RequestOptions options = null)
         {
-            var response = new API.InteractionResponse()
+            var response = new API.InteractionResponse
             {
                 Type = InteractionResponseType.DeferredUpdateMessage,
-                Data = ephemeral ? new API.InteractionCallbackData() { Flags = MessageFlags.Ephemeral } : Optional<API.InteractionCallbackData>.Unspecified
+                Data = ephemeral ? new API.InteractionCallbackData { Flags = MessageFlags.Ephemeral } : Optional<API.InteractionCallbackData>.Unspecified
 
             };
 

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Message Components/SocketMessageComponentData.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Message Components/SocketMessageComponentData.cs
@@ -1,8 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Model = Discord.API.MessageComponentInteractionData;
 
 namespace Discord.WebSocket

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketAutocompleteInteraction.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketAutocompleteInteraction.cs
@@ -2,8 +2,6 @@ using Discord.Rest;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Model = Discord.API.Interaction;
 using DataModel = Discord.API.AutocompleteInteractionData;
@@ -76,22 +74,27 @@ namespace Discord.WebSocket
 
         /// <inheritdoc/>
         [Obsolete("Autocomplete interactions cannot be deferred!", true)]
-        public override Task DeferAsync(bool ephemeral = false, RequestOptions options = null) => throw new NotSupportedException();
+        public override Task DeferAsync(bool ephemeral = false, RequestOptions options = null)
+            => throw new NotSupportedException("Autocomplete interactions cannot be deferred!");
 
         /// <inheritdoc/>
         [Obsolete("Autocomplete interactions cannot have followups!", true)]
-        public override Task<RestFollowupMessage> FollowupAsync(string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, RequestOptions options = null, MessageComponent component = null, Embed embed = null) => throw new NotSupportedException();
+        public override Task<RestFollowupMessage> FollowupAsync(string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, RequestOptions options = null, MessageComponent component = null, Embed embed = null)
+            => throw new NotSupportedException("Autocomplete interactions cannot be deferred!");
 
         /// <inheritdoc/>
         [Obsolete("Autocomplete interactions cannot have followups!", true)]
-        public override Task<RestFollowupMessage> FollowupWithFileAsync(Stream fileStream, string fileName, string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, RequestOptions options = null, MessageComponent component = null, Embed embed = null) => throw new NotSupportedException();
+        public override Task<RestFollowupMessage> FollowupWithFileAsync(Stream fileStream, string fileName, string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, RequestOptions options = null, MessageComponent component = null, Embed embed = null)
+            => throw new NotSupportedException("Autocomplete interactions cannot be deferred!");
 
         /// <inheritdoc/>
         [Obsolete("Autocomplete interactions cannot have followups!", true)]
-        public override Task<RestFollowupMessage> FollowupWithFileAsync(string filePath, string text = null, string fileName = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, RequestOptions options = null, MessageComponent component = null, Embed embed = null) => throw new NotSupportedException();
+        public override Task<RestFollowupMessage> FollowupWithFileAsync(string filePath, string text = null, string fileName = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, RequestOptions options = null, MessageComponent component = null, Embed embed = null)
+            => throw new NotSupportedException("Autocomplete interactions cannot be deferred!");
 
         /// <inheritdoc/>
         [Obsolete("Autocomplete interactions cannot have normal responses!", true)]
-        public override Task RespondAsync(string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, RequestOptions options = null, MessageComponent component = null, Embed embed = null) => throw new NotSupportedException();
+        public override Task RespondAsync(string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, RequestOptions options = null, MessageComponent component = null, Embed embed = null)
+            => throw new NotSupportedException("Autocomplete interactions cannot be deferred!");
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketAutocompleteInteraction.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketAutocompleteInteraction.cs
@@ -52,7 +52,7 @@ namespace Discord.WebSocket
         ///     A task that represents the asynchronous operation of responding to this interaction.
         /// </returns>
         public Task RespondAsync(IEnumerable<AutocompleteResult> result, RequestOptions options = null)
-            => InteractionHelper.SendAutocompleteResult(Discord, result, Id, Token, options);
+            => InteractionHelper.SendAutocompleteResultAsync(Discord, result, Id, Token, options);
 
         /// <summary>
         ///     Responds to this interaction with a set of choices.
@@ -69,7 +69,7 @@ namespace Discord.WebSocket
         ///     A task that represents the asynchronous operation of responding to this interaction.
         /// </returns>
         public Task RespondAsync(RequestOptions options = null, params AutocompleteResult[] result)
-            => InteractionHelper.SendAutocompleteResult(Discord, result, Id, Token, options);
+            => InteractionHelper.SendAutocompleteResultAsync(Discord, result, Id, Token, options);
 
 
         /// <inheritdoc/>

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketAutocompleteInteraction.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketAutocompleteInteraction.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Model = Discord.API.Interaction;
 using DataModel = Discord.API.AutocompleteInteractionData;
 
-
 namespace Discord.WebSocket
 {
     /// <summary>
@@ -70,7 +69,6 @@ namespace Discord.WebSocket
         /// </returns>
         public Task RespondAsync(RequestOptions options = null, params AutocompleteResult[] result)
             => InteractionHelper.SendAutocompleteResultAsync(Discord, result, Id, Token, options);
-
 
         /// <inheritdoc/>
         [Obsolete("Autocomplete interactions cannot be deferred!", true)]

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketAutocompleteInteractionData.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketAutocompleteInteractionData.cs
@@ -1,9 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using DataModel = Discord.API.AutocompleteInteractionData;
 
 
@@ -46,12 +43,12 @@ namespace Discord.WebSocket
 
         internal SocketAutocompleteInteractionData(DataModel model)
         {
-            var options = model.Options.SelectMany(x => GetOptions(x));
+            var options = model.Options.SelectMany(GetOptions);
 
             Current = options.FirstOrDefault(x => x.Focused);
             Options = options.ToImmutableArray();
 
-            if (options != null && options.Count() == 1 && Current == null)
+            if (Options.Count == 1 && Current == null)
                 Current = Options.FirstOrDefault();
 
             CommandName = model.Name;
@@ -62,11 +59,11 @@ namespace Discord.WebSocket
 
         private List<AutocompleteOption> GetOptions(API.AutocompleteInteractionDataOption model)
         {
-            List<AutocompleteOption> options = new List<AutocompleteOption>();
+            var options = new List<AutocompleteOption>();
 
             if (model.Options.IsSpecified)
             {
-                options.AddRange(model.Options.Value.SelectMany(x => GetOptions(x)));
+                options.AddRange(model.Options.Value.SelectMany(GetOptions));
             }
             else if(model.Focused.IsSpecified)
             {

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketAutocompleteInteractionData.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketAutocompleteInteractionData.cs
@@ -3,7 +3,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using DataModel = Discord.API.AutocompleteInteractionData;
 
-
 namespace Discord.WebSocket
 {
     /// <summary>

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommand.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommand.cs
@@ -16,8 +16,8 @@ namespace Discord.WebSocket
         internal SocketSlashCommand(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
             : base(client, model, channel)
         {
-            var dataModel = model.Data.IsSpecified ?
-                (DataModel)model.Data.Value
+            var dataModel = model.Data.IsSpecified
+                ? (DataModel)model.Data.Value
                 : null;
 
             ulong? guildId = null;

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommand.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommand.cs
@@ -1,7 +1,3 @@
-using Discord.Rest;
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 using DataModel = Discord.API.ApplicationCommandInteractionData;
 using Model = Discord.API.Interaction;
 
@@ -15,7 +11,7 @@ namespace Discord.WebSocket
         /// <summary>
         ///     The data associated with this interaction.
         /// </summary>
-        new public SocketSlashCommandData Data { get; }
+        private new SocketSlashCommandData Data { get; }
 
         internal SocketSlashCommand(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
             : base(client, model, channel)
@@ -31,7 +27,7 @@ namespace Discord.WebSocket
             Data = SocketSlashCommandData.Create(client, dataModel, guildId);
         }
 
-        new internal static SocketInteraction Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
+        internal new static SocketInteraction Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
         {
             var entity = new SocketSlashCommand(client, model, channel);
             entity.Update(model);

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommandData.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommandData.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Model = Discord.API.ApplicationCommandInteractionData;
@@ -25,7 +24,7 @@ namespace Discord.WebSocket
 
             Options = model.Options.IsSpecified
                 ? model.Options.Value.Select(x => new SocketSlashCommandDataOption(this, x)).ToImmutableArray()
-                : null;
+                : ImmutableArray.Create<SocketSlashCommandDataOption>();
         }
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommandDataOption.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommandDataOption.cs
@@ -110,7 +110,6 @@ namespace Discord.WebSocket
                         }
                         break;
                 }
-
             }
 
             Options = model.Options.IsSpecified

--- a/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommandDataOption.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/Slash Commands/SocketSlashCommandDataOption.cs
@@ -6,7 +6,7 @@ using Model = Discord.API.ApplicationCommandInteractionDataOption;
 namespace Discord.WebSocket
 {
     /// <summary>
-    ///     Represents a Websocket-based <see cref="IApplicationCommandInteractionDataOption"/> received by the gateway
+    ///     Represents a Websocket-based <see cref="IApplicationCommandInteractionDataOption"/> received by the gateway.
     /// </summary>
     public class SocketSlashCommandDataOption : IApplicationCommandInteractionDataOption
     {
@@ -61,7 +61,7 @@ namespace Discord.WebSocket
                                     break;
                                 case ApplicationCommandOptionType.Mentionable:
                                     {
-                                        if(data.ResolvableData.GuildMembers.Any(x => x.Key == valueId) || data.ResolvableData.Users.Any(x => x.Key == valueId))
+                                        if (data.ResolvableData.GuildMembers.Any(x => x.Key == valueId) || data.ResolvableData.Users.Any(x => x.Key == valueId))
                                         {
                                             var guildUser = data.ResolvableData.GuildMembers.FirstOrDefault(x => x.Key == valueId).Value;
 
@@ -70,7 +70,7 @@ namespace Discord.WebSocket
                                             else
                                                 Value = data.ResolvableData.Users.FirstOrDefault(x => x.Key == valueId).Value;
                                         }
-                                        else if(data.ResolvableData.Roles.Any(x => x.Key == valueId))
+                                        else if (data.ResolvableData.Roles.Any(x => x.Key == valueId))
                                         {
                                             Value = data.ResolvableData.Roles.FirstOrDefault(x => x.Key == valueId).Value;
                                         }
@@ -115,9 +115,9 @@ namespace Discord.WebSocket
 
             Options = model.Options.IsSpecified
                 ? model.Options.Value.Select(x => new SocketSlashCommandDataOption(data, x)).ToImmutableArray()
-                : null;
+                : ImmutableArray.Create<SocketSlashCommandDataOption>();
         }
-#endregion
+        #endregion
 
         #region Converters
         public static explicit operator bool(SocketSlashCommandDataOption option)

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommand.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommand.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using GatewayModel = Discord.API.Gateway.ApplicationCommandCreatedUpdatedEvent;
 using Model = Discord.API.ApplicationCommand;
@@ -11,7 +10,7 @@ using Model = Discord.API.ApplicationCommand;
 namespace Discord.WebSocket
 {
     /// <summary>
-    ///     Represends a Websocket-based <see cref="IApplicationCommand"/>.
+    ///     Represents a Websocket-based <see cref="IApplicationCommand"/>.
     /// </summary>
     public class SocketApplicationCommand : SocketEntity<ulong>, IApplicationCommand
     {
@@ -85,33 +84,26 @@ namespace Discord.WebSocket
             Type = model.Type;
 
             Options = model.Options.IsSpecified
-                ? model.Options.Value.Select(x => SocketApplicationCommandOption.Create(x)).ToImmutableArray()
-                : new ImmutableArray<SocketApplicationCommandOption>();
+                ? model.Options.Value.Select(SocketApplicationCommandOption.Create).ToImmutableArray()
+                : ImmutableArray.Create<SocketApplicationCommandOption>();
         }
 
         /// <inheritdoc/>
         public Task DeleteAsync(RequestOptions options = null)
-            => InteractionHelper.DeleteUnknownApplicationCommand(Discord, GuildId, this, options);
+            => InteractionHelper.DeleteUnknownApplicationCommandAsync(Discord, GuildId, this, options);
 
         /// <inheritdoc />
         public Task ModifyAsync(Action<ApplicationCommandProperties> func, RequestOptions options = null)
         {
             return ModifyAsync<ApplicationCommandProperties>(func, options);
         }
-        
+
         /// <inheritdoc />
         public async Task ModifyAsync<TArg>(Action<TArg> func, RequestOptions options = null) where TArg : ApplicationCommandProperties
         {
-            Model command = null;
-
-            if (IsGlobalCommand)
-            {
-                command = await InteractionHelper.ModifyGlobalCommand<TArg>(Discord, this, func, options).ConfigureAwait(false);
-            }
-            else
-            {
-                command = await InteractionHelper.ModifyGuildCommand<TArg>(Discord, this, GuildId.Value, func, options);
-            }
+            var command = IsGlobalCommand
+                ? await InteractionHelper.ModifyGlobalCommandAsync(Discord, this, func, options).ConfigureAwait(false)
+                : await InteractionHelper.ModifyGuildCommandAsync(Discord, this, GuildId.Value, func, options);
 
             Update(command);
         }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommandChoice.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommandChoice.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Model = Discord.API.ApplicationCommandOptionChoice;
 
 namespace Discord.WebSocket

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommandOption.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommandOption.cs
@@ -1,9 +1,6 @@
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Model = Discord.API.ApplicationCommandOption;
 
 namespace Discord.WebSocket
@@ -66,16 +63,16 @@ namespace Discord.WebSocket
                 : null;
 
             Choices = model.Choices.IsSpecified
-                ? model.Choices.Value.Select(x => SocketApplicationCommandChoice.Create(x)).ToImmutableArray()
-                : new ImmutableArray<SocketApplicationCommandChoice>();
+                ? model.Choices.Value.Select(SocketApplicationCommandChoice.Create).ToImmutableArray()
+                : ImmutableArray.Create<SocketApplicationCommandChoice>();
 
             Options = model.Options.IsSpecified
-                ? model.Options.Value.Select(x => SocketApplicationCommandOption.Create(x)).ToImmutableArray()
-                : new ImmutableArray<SocketApplicationCommandOption>();
+                ? model.Options.Value.Select(Create).ToImmutableArray()
+                : ImmutableArray.Create<SocketApplicationCommandOption>();
 
             ChannelTypes = model.ChannelTypes.IsSpecified
                 ? model.ChannelTypes.Value.ToImmutableArray()
-                : new ImmutableArray<ChannelType>();
+                : ImmutableArray.Create<ChannelType>();
         }
 
         IReadOnlyCollection<IApplicationCommandOptionChoice> IApplicationCommandOption.Choices => Choices;

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketCommandBase.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketCommandBase.cs
@@ -1,10 +1,8 @@
 using Discord.Net.Rest;
 using Discord.Rest;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using DataModel = Discord.API.ApplicationCommandInteractionData;
 using Model = Discord.API.Interaction;
@@ -31,7 +29,7 @@ namespace Discord.WebSocket
         /// <summary>
         ///     The data associated with this interaction.
         /// </summary>
-        new internal SocketCommandBaseData Data { get; }
+        internal new SocketCommandBaseData Data { get; }
 
         internal SocketCommandBase(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
             : base(client, model.Id, channel)
@@ -47,7 +45,7 @@ namespace Discord.WebSocket
             Data = SocketCommandBaseData.Create(client, dataModel, model.Id, guildId);
         }
 
-        new internal static SocketInteraction Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
+        internal new static SocketInteraction Create(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
         {
             var entity = new SocketCommandBase(client, model, channel);
             entity.Update(model);
@@ -85,7 +83,7 @@ namespace Discord.WebSocket
 
             Preconditions.AtMost(allowedMentions?.RoleIds?.Count ?? 0, 100, nameof(allowedMentions.RoleIds), "A max of 100 role Ids are allowed.");
             Preconditions.AtMost(allowedMentions?.UserIds?.Count ?? 0, 100, nameof(allowedMentions.UserIds), "A max of 100 user Ids are allowed.");
-            Preconditions.AtMost(embeds?.Length ?? 0, 10, nameof(embeds), "A max of 10 embeds are allowed.");
+            Preconditions.AtMost(embeds.Length, 10, nameof(embeds), "A max of 10 embeds are allowed.");
 
             // check that user flag and user Id list are exclusive, same with role flag and role Id list
             if (allowedMentions != null && allowedMentions.AllowedTypes.HasValue)
@@ -110,14 +108,14 @@ namespace Discord.WebSocket
                 {
                     Content = text,
                     AllowedMentions = allowedMentions?.ToModel() ?? Optional<API.AllowedMentions>.Unspecified,
-                    Embeds = embeds?.Select(x => x.ToModel()).ToArray() ?? Optional<API.Embed[]>.Unspecified,
-                    TTS = isTTS ? true : Optional<bool>.Unspecified,
+                    Embeds = embeds.Select(x => x.ToModel()).ToArray(),
+                    TTS = isTTS,
                     Components = component?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? Optional<API.ActionRowComponent[]>.Unspecified,
                     Flags = ephemeral ? MessageFlags.Ephemeral : Optional<MessageFlags>.Unspecified
                 }
             };
 
-            await InteractionHelper.SendInteractionResponse(Discord, response, Id, Token, options);
+            await InteractionHelper.SendInteractionResponseAsync(Discord, response, Id, Token, options);
         }
 
         /// <inheritdoc/>
@@ -140,14 +138,14 @@ namespace Discord.WebSocket
 
             Preconditions.AtMost(allowedMentions?.RoleIds?.Count ?? 0, 100, nameof(allowedMentions.RoleIds), "A max of 100 role Ids are allowed.");
             Preconditions.AtMost(allowedMentions?.UserIds?.Count ?? 0, 100, nameof(allowedMentions.UserIds), "A max of 100 user Ids are allowed.");
-            Preconditions.AtMost(embeds?.Length ?? 0, 10, nameof(embeds), "A max of 10 embeds are allowed.");
+            Preconditions.AtMost(embeds.Length, 10, nameof(embeds), "A max of 10 embeds are allowed.");
 
             var args = new API.Rest.CreateWebhookMessageParams
             {
                 Content = text,
                 AllowedMentions = allowedMentions?.ToModel() ?? Optional<API.AllowedMentions>.Unspecified,
                 IsTTS = isTTS,
-                Embeds = embeds?.Select(x => x.ToModel()).ToArray() ?? Optional<API.Embed[]>.Unspecified,
+                Embeds = embeds.Select(x => x.ToModel()).ToArray(),
                 Components = component?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? Optional<API.ActionRowComponent[]>.Unspecified
             };
 
@@ -179,7 +177,7 @@ namespace Discord.WebSocket
 
             Preconditions.AtMost(allowedMentions?.RoleIds?.Count ?? 0, 100, nameof(allowedMentions.RoleIds), "A max of 100 role Ids are allowed.");
             Preconditions.AtMost(allowedMentions?.UserIds?.Count ?? 0, 100, nameof(allowedMentions.UserIds), "A max of 100 user Ids are allowed.");
-            Preconditions.AtMost(embeds?.Length ?? 0, 10, nameof(embeds), "A max of 10 embeds are allowed.");
+            Preconditions.AtMost(embeds.Length, 10, nameof(embeds), "A max of 10 embeds are allowed.");
             Preconditions.NotNull(fileStream, nameof(fileStream), "File Stream must have data");
             Preconditions.NotNullOrEmpty(fileName, nameof(fileName), "File Name must not be empty or null");
 
@@ -188,7 +186,7 @@ namespace Discord.WebSocket
                 Content = text,
                 AllowedMentions = allowedMentions?.ToModel() ?? Optional<API.AllowedMentions>.Unspecified,
                 IsTTS = isTTS,
-                Embeds = embeds?.Select(x => x.ToModel()).ToArray() ?? Optional<API.Embed[]>.Unspecified,
+                Embeds = embeds.Select(x => x.ToModel()).ToArray(),
                 Components = component?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? Optional<API.ActionRowComponent[]>.Unspecified,
                 File = fileStream is not null ? new MultipartFile(fileStream, fileName) : Optional<MultipartFile>.Unspecified
             };
@@ -221,7 +219,7 @@ namespace Discord.WebSocket
 
             Preconditions.AtMost(allowedMentions?.RoleIds?.Count ?? 0, 100, nameof(allowedMentions.RoleIds), "A max of 100 role Ids are allowed.");
             Preconditions.AtMost(allowedMentions?.UserIds?.Count ?? 0, 100, nameof(allowedMentions.UserIds), "A max of 100 user Ids are allowed.");
-            Preconditions.AtMost(embeds?.Length ?? 0, 10, nameof(embeds), "A max of 10 embeds are allowed.");
+            Preconditions.AtMost(embeds.Length, 10, nameof(embeds), "A max of 10 embeds are allowed.");
             Preconditions.NotNullOrEmpty(filePath, nameof(filePath), "Path must exist");
 
             fileName ??= Path.GetFileName(filePath);
@@ -232,7 +230,7 @@ namespace Discord.WebSocket
                 Content = text,
                 AllowedMentions = allowedMentions?.ToModel() ?? Optional<API.AllowedMentions>.Unspecified,
                 IsTTS = isTTS,
-                Embeds = embeds?.Select(x => x.ToModel()).ToArray() ?? Optional<API.Embed[]>.Unspecified,
+                Embeds = embeds.Select(x => x.ToModel()).ToArray(),
                 Components = component?.Components.Select(x => new API.ActionRowComponent(x)).ToArray() ?? Optional<API.ActionRowComponent[]>.Unspecified,
                 File = !string.IsNullOrEmpty(filePath) ? new MultipartFile(new MemoryStream(File.ReadAllBytes(filePath), false), fileName) : Optional<MultipartFile>.Unspecified
             };

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketCommandBase.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketCommandBase.cs
@@ -34,8 +34,8 @@ namespace Discord.WebSocket
         internal SocketCommandBase(DiscordSocketClient client, Model model, ISocketMessageChannel channel)
             : base(client, model.Id, channel)
         {
-            var dataModel = model.Data.IsSpecified ?
-                (DataModel)model.Data.Value
+            var dataModel = model.Data.IsSpecified
+                ? (DataModel)model.Data.Value
                 : null;
 
             ulong? guildId = null;
@@ -54,8 +54,8 @@ namespace Discord.WebSocket
 
         internal override void Update(Model model)
         {
-            var data = model.Data.IsSpecified ?
-                (DataModel)model.Data.Value
+            var data = model.Data.IsSpecified
+                ? (DataModel)model.Data.Value
                 : null;
 
             Data.Update(data);

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketCommandBaseData.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketCommandBaseData.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using Model = Discord.API.ApplicationCommandInteractionData;
 
 namespace Discord.WebSocket

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketResolvableData.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketResolvableData.cs
@@ -1,8 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Discord.WebSocket
 {

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketInteraction.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketInteraction.cs
@@ -75,15 +75,17 @@ namespace Discord.WebSocket
                     ApplicationCommandType.Slash => SocketSlashCommand.Create(client, model, channel),
                     ApplicationCommandType.Message => SocketMessageCommand.Create(client, model, channel),
                     ApplicationCommandType.User => SocketUserCommand.Create(client, model, channel),
-                    _ => null,
+                    _ => null
                 };
             }
-            else if (model.Type == InteractionType.MessageComponent)
+
+            if (model.Type == InteractionType.MessageComponent)
                 return SocketMessageComponent.Create(client, model, channel);
-            else if (model.Type == InteractionType.ApplicationCommandAutocomplete)
+
+            if (model.Type == InteractionType.ApplicationCommandAutocomplete)
                 return SocketAutocompleteInteraction.Create(client, model, channel);
-            else
-                return null;
+
+            return null;
         }
 
         internal virtual void Update(Model model)
@@ -138,7 +140,7 @@ namespace Discord.WebSocket
         /// <returns>
         ///     The sent message.
         /// </returns>
-        public abstract Task<RestFollowupMessage> FollowupAsync(string text = null, Embed[] embeds = null,  bool isTTS = false, bool ephemeral = false,
+        public abstract Task<RestFollowupMessage> FollowupAsync(string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false,
              AllowedMentions allowedMentions = null, RequestOptions options = null, MessageComponent component = null, Embed embed = null);
 
         /// <summary>
@@ -195,7 +197,7 @@ namespace Discord.WebSocket
         /// <returns>A <see cref="RestInteractionMessage"/> that represents the initial response.</returns>
         public async Task<RestInteractionMessage> ModifyOriginalResponseAsync(Action<MessageProperties> func, RequestOptions options = null)
         {
-            var model = await InteractionHelper.ModifyInteractionResponse(Discord, Token, func, options);
+            var model = await InteractionHelper.ModifyInteractionResponseAsync(Discord, Token, func, options);
             return RestInteractionMessage.Create(Discord, model, Token, Channel);
         }
 
@@ -214,20 +216,20 @@ namespace Discord.WebSocket
             // Tokens last for 15 minutes according to https://discord.com/developers/docs/interactions/slash-commands#responding-to-an-interaction
             return (DateTime.UtcNow - CreatedAt.UtcDateTime).TotalMinutes <= 15d;
         }
-#endregion
+        #endregion
 
         #region  IDiscordInteraction
         /// <inheritdoc/>
-        async Task<IUserMessage> IDiscordInteraction.FollowupAsync (string text, Embed[] embeds, bool isTTS, bool ephemeral, AllowedMentions allowedMentions,
+        async Task<IUserMessage> IDiscordInteraction.FollowupAsync(string text, Embed[] embeds, bool isTTS, bool ephemeral, AllowedMentions allowedMentions,
             RequestOptions options, MessageComponent component, Embed embed)
             => await FollowupAsync(text, embeds, isTTS, ephemeral, allowedMentions, options, component, embed).ConfigureAwait(false);
 
         /// <inheritdoc/>
-        async Task<IUserMessage> IDiscordInteraction.GetOriginalResponseAsync (RequestOptions options)
+        async Task<IUserMessage> IDiscordInteraction.GetOriginalResponseAsync(RequestOptions options)
             => await GetOriginalResponseAsync(options).ConfigureAwait(false);
 
         /// <inheritdoc/>
-        async Task<IUserMessage> IDiscordInteraction.ModifyOriginalResponseAsync (Action<MessageProperties> func, RequestOptions options)
+        async Task<IUserMessage> IDiscordInteraction.ModifyOriginalResponseAsync(Action<MessageProperties> func, RequestOptions options)
             => await ModifyOriginalResponseAsync(func, options).ConfigureAwait(false);
         #endregion
     }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketInteraction.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketInteraction.cs
@@ -63,9 +63,9 @@ namespace Discord.WebSocket
         {
             if (model.Type == InteractionType.ApplicationCommand)
             {
-                var dataModel = model.Data.IsSpecified ?
-                        (DataModel)model.Data.Value
-                        : null;
+                var dataModel = model.Data.IsSpecified
+                    ? (DataModel)model.Data.Value
+                    : null;
 
                 if (dataModel == null)
                     return null;

--- a/src/Discord.Net.WebSocket/Entities/Stickers/SocketCustomSticker.cs
+++ b/src/Discord.Net.WebSocket/Entities/Stickers/SocketCustomSticker.cs
@@ -1,9 +1,6 @@
 using Discord.Rest;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Model = Discord.API.Sticker;
 
@@ -54,7 +51,7 @@ namespace Discord.WebSocket
         /// <inheritdoc/>
         public async Task ModifyAsync(Action<StickerProperties> func, RequestOptions options = null)
         {
-            if(!Guild.CurrentUser.GuildPermissions.Has(GuildPermission.ManageEmojisAndStickers))
+            if (!Guild.CurrentUser.GuildPermissions.Has(GuildPermission.ManageEmojisAndStickers))
                 throw new InvalidOperationException($"Missing permission {nameof(GuildPermission.ManageEmojisAndStickers)}");
 
             var model = await GuildHelper.ModifyStickerAsync(Discord, Guild.Id, this, func, options);
@@ -72,7 +69,7 @@ namespace Discord.WebSocket
         internal SocketCustomSticker Clone() => MemberwiseClone() as SocketCustomSticker;
 
         private new string DebuggerDisplay => Guild == null ? base.DebuggerDisplay : $"{Name} in {Guild.Name} ({Id})";
-#endregion
+        #endregion
 
         #region  ICustomSticker
         ulong? ICustomSticker.AuthorId

--- a/src/Discord.Net.WebSocket/Entities/Stickers/SocketCustomSticker.cs
+++ b/src/Discord.Net.WebSocket/Entities/Stickers/SocketCustomSticker.cs
@@ -4,7 +4,6 @@ using System.Diagnostics;
 using System.Threading.Tasks;
 using Model = Discord.API.Sticker;
 
-
 namespace Discord.WebSocket
 {
     /// <summary>

--- a/src/Discord.Net.WebSocket/Entities/Stickers/SocketSticker.cs
+++ b/src/Discord.Net.WebSocket/Entities/Stickers/SocketSticker.cs
@@ -1,11 +1,7 @@
-using Discord.Rest;
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Model = Discord.API.Sticker;
 
 namespace Discord.WebSocket
@@ -49,12 +45,9 @@ namespace Discord.WebSocket
 
         internal static SocketSticker Create(DiscordSocketClient client, Model model)
         {
-            SocketSticker entity;
-
-            if (model.GuildId.IsSpecified)
-                entity = new SocketCustomSticker(client, model.Id, client.GetGuild(model.GuildId.Value), model.User.IsSpecified ? model.User.Value.Id : null);
-            else
-                entity = new SocketSticker(client, model.Id);
+            var entity = model.GuildId.IsSpecified
+                ? new SocketCustomSticker(client, model.Id, client.GetGuild(model.GuildId.Value), model.User.IsSpecified ? model.User.Value.Id : null)
+                : new SocketSticker(client, model.Id);
 
             entity.Update(model);
             return entity;
@@ -63,21 +56,16 @@ namespace Discord.WebSocket
         internal virtual void Update(Model model)
         {
             Name = model.Name;
-            Description = model.Desription;
+            Description = model.Description;
             PackId = model.PackId;
             IsAvailable = model.Available;
             Format = model.FormatType;
             Type = model.Type;
             SortOrder = model.SortValue;
 
-            if (model.Tags.IsSpecified)
-            {
-                Tags = model.Tags.Value.Split(',').Select(x => x.Trim()).ToImmutableArray();
-            }
-            else
-            {
-                Tags = ImmutableArray<string>.Empty;
-            }
+            Tags = model.Tags.IsSpecified
+                ? model.Tags.Value.Split(',').Select(x => x.Trim()).ToImmutableArray()
+                : ImmutableArray.Create<string>();
         }
 
         internal string DebuggerDisplay => $"{Name} ({Id})";
@@ -85,10 +73,10 @@ namespace Discord.WebSocket
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            if (obj is API.Sticker stickerModel)
+            if (obj is Model stickerModel)
             {
                 return stickerModel.Name == Name &&
-                    stickerModel.Desription == Description &&
+                    stickerModel.Description == Description &&
                     stickerModel.FormatType == Format &&
                     stickerModel.Id == Id &&
                     stickerModel.PackId == PackId &&
@@ -97,8 +85,8 @@ namespace Discord.WebSocket
                     stickerModel.Available == IsAvailable &&
                     (!stickerModel.Tags.IsSpecified || stickerModel.Tags.Value == string.Join(", ", Tags));
             }
-            else
-                return base.Equals(obj);
+
+            return base.Equals(obj);
         }
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Stickers/SocketUnknownSticker.cs
+++ b/src/Discord.Net.WebSocket/Entities/Stickers/SocketUnknownSticker.cs
@@ -1,8 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Model = Discord.API.StickerItem;
 

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketThreadUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketThreadUser.cs
@@ -160,7 +160,6 @@ namespace Discord.WebSocket
             }
         }
 
-
         /// <inheritdoc/>
         public ChannelPermissions GetPermissions(IGuildChannel channel) => GuildUser.GetPermissions(channel);
 

--- a/src/Discord.Net.WebSocket/Entities/Users/SocketThreadUser.cs
+++ b/src/Discord.Net.WebSocket/Entities/Users/SocketThreadUser.cs
@@ -1,11 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Model = Discord.API.ThreadMember;
-using MemberModel = Discord.API.GuildMember;
-using Discord.API;
 using System.Collections.Immutable;
 
 namespace Discord.WebSocket


### PR DESCRIPTION
This PR makes a general cleanup of the codebase, specifically the files that are present in Discord.Net Labs but not in Discord.Net. 

The changes are the following:

- Fix null collections
- Fix typos
- Fix formatting
- Fix `ThreadMember` `Presence` property not being deserialized due to a typo
- Fix unused `RequestOptions` in `GetActiveThreadsAsync`
- Use `Array.Empty` instead of zero-length arrays
- Use more specific exceptions
- Use method group
- Use computed properties
- Use conditional access
- Use `var`
- Use `??` and `??=`
- Use switch expressions
- Use expression body in getters and setters
- Use `Async` suffix
- Remove redundancies
- Remove trailing commas
- Remove unreachable code
- Remove unnecessary usings, whitespace, parentheses, etc
- Other minor changes

This PR doesn't have any breaking changes, except the change of the type of exceptions that are thrown in some parts.