### PR TITLE
Added support for GUILD_JOIN_REQUEST_DELETE event

### DIFF
--- a/src/Discord.Net.WebSocket/API/Gateway/GuildJoinRequestDeleteEvent.cs
+++ b/src/Discord.Net.WebSocket/API/Gateway/GuildJoinRequestDeleteEvent.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json;
+
+namespace Discord.API.Gateway
+{
+    internal class GuildJoinRequestDeleteEvent
+    {
+        [JsonProperty("user_id")]
+        public ulong UserId { get; set; }
+        [JsonProperty("guild_id")]
+        public ulong GuildId { get; set; }
+    }
+}

--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -335,6 +335,13 @@ namespace Discord.WebSocket
             remove { _guildUpdatedEvent.Remove(value); }
         }
         internal readonly AsyncEvent<Func<SocketGuild, SocketGuild, Task>> _guildUpdatedEvent = new AsyncEvent<Func<SocketGuild, SocketGuild, Task>>();
+        /// <summary>Fired when a user leaves without agreeing to the member screening </summary>
+        public event Func<ulong, ulong, Task> GuildJoinRequestDeleted
+        {
+            add { _guildJoinRequestDeletedEvent.Add(value); }
+            remove { _guildJoinRequestDeletedEvent.Remove(value); }
+        }
+        internal readonly AsyncEvent<Func<ulong, ulong, Task>> _guildJoinRequestDeletedEvent = new AsyncEvent<Func<ulong, ulong, Task>>();
         #endregion
 
         #region Users

--- a/src/Discord.Net.WebSocket/DiscordShardedClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordShardedClient.cs
@@ -485,6 +485,7 @@ namespace Discord.WebSocket
             client.GuildStickerCreated += (sticker) => _guildStickerCreated.InvokeAsync(sticker);
             client.GuildStickerDeleted += (sticker) => _guildStickerDeleted.InvokeAsync(sticker);
             client.GuildStickerUpdated += (before, after) => _guildStickerUpdated.InvokeAsync(before, after);
+            client.GuildJoinRequestDeleted += (userId, guildId) => _guildJoinRequestDeletedEvent.InvokeAsync(userId, guildId);
         }
 #endregion
 

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1004,6 +1004,14 @@ namespace Discord.WebSocket
                                     }
                                 }
                                 break;
+                            case "GUILD_JOIN_REQUEST_DELETE":
+                                {
+                                    await _gatewayLogger.DebugAsync("Received Dispatch (GUILD_JOIN_REQUEST_DELETE)").ConfigureAwait(false);
+
+                                    var data = (payload as JToken).ToObject<GuildJoinRequestDeleteEvent>(_serializer);
+                                    await TimedInvokeAsync(_guildJoinRequestDeletedEvent, nameof(GuildJoinRequestDeleted), data.UserId, data.GuildId).ConfigureAwait(false);
+                                }
+                                break;
                             #endregion
 
                             #region Channels


### PR DESCRIPTION
Fixes #247

The `GUILD_JOIN_REQUEST_DELETE` event is fired when a user leaves the server without completing the member screening. The only data returned is the `user_id` and `guild_id`. A user can add this event by adding `GuildJoinRequestDeleted` where the first arg is the `user_id` and the second is the `guild_id`.