### PR TITLE
Support Guild Boost Progress Bars

### DIFF
--- a/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
@@ -108,5 +108,9 @@ namespace Discord
         ///     the value of <see cref="PreferredCulture"/> will be unused.
         /// </remarks>
         public Optional<CultureInfo> PreferredCulture { get; set; }
+        /// <summary>
+        ///     Gets ir Sets if the boost progress bar is enabled
+        /// </summary>
+        public Optional<bool> IsBoostProgressBarEnabled { get; set; }
     }
 }

--- a/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
@@ -109,7 +109,7 @@ namespace Discord
         /// </remarks>
         public Optional<CultureInfo> PreferredCulture { get; set; }
         /// <summary>
-        ///     Gets or Sets if the boost progress bar is enabled.
+        ///     Gets or sets if the boost progress bar is enabled.
         /// </summary>
         public Optional<bool> IsBoostProgressBarEnabled { get; set; }
     }

--- a/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/GuildProperties.cs
@@ -109,7 +109,7 @@ namespace Discord
         /// </remarks>
         public Optional<CultureInfo> PreferredCulture { get; set; }
         /// <summary>
-        ///     Gets ir Sets if the boost progress bar is enabled
+        ///     Gets or Sets if the boost progress bar is enabled.
         /// </summary>
         public Optional<bool> IsBoostProgressBarEnabled { get; set; }
     }

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -340,10 +340,10 @@ namespace Discord
         /// </returns>
         CultureInfo PreferredCulture { get; }
         /// <summary>
-        ///     Detimines if the boost progress bar is enabled
+        ///     Determines if the boost progress bar is enabled.
         /// </summary>
         /// <returns>
-        ///     <see langword="true"/> if the boost progress bar is enabled; otherwise <see langword="false"/>
+        ///     <see langword="true"/> if the boost progress bar is enabled; otherwise <see langword="false"/>.
         /// </returns>
         bool IsBoostProgressBarEnabled { get; }
 

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -339,6 +339,13 @@ namespace Discord
         ///     The preferred culture information of this guild.
         /// </returns>
         CultureInfo PreferredCulture { get; }
+        /// <summary>
+        ///     Detimines if the boost progress bar is enabled
+        /// </summary>
+        /// <returns>
+        ///     <see langword="true"/> if the boost progress bar is enabled; otherwise <see langword="false"/>
+        /// </returns>
+        bool IsBoostProgressBarEnabled { get; }
 
         /// <summary>
         ///     Modifies this guild.

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -340,7 +340,7 @@ namespace Discord
         /// </returns>
         CultureInfo PreferredCulture { get; }
         /// <summary>
-        ///     Determines if the boost progress bar is enabled.
+        ///     Gets whether the guild has the boost progress bar enabled.
         /// </summary>
         /// <returns>
         ///     <see langword="true"/> if the boost progress bar is enabled; otherwise <see langword="false"/>.

--- a/src/Discord.Net.Rest/API/Common/Guild.cs
+++ b/src/Discord.Net.Rest/API/Common/Guild.cs
@@ -81,5 +81,7 @@ namespace Discord.API
         public NsfwLevel NsfwLevel { get; set; }
         [JsonProperty("stickers")]
         public Sticker[] Stickers { get; set; }
+        [JsonProperty("premium_progress_bar_enabled")]
+        public Optional<bool> IsBoostProgressBarEnabled { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildParams.cs
@@ -35,5 +35,7 @@ namespace Discord.API.Rest
         public Optional<SystemChannelMessageDeny> SystemChannelFlags { get; set; }
         [JsonProperty("preferred_locale")]
         public string PreferredLocale { get; set; }
+        [JsonProperty("premium_progress_bar_enabled")]
+        public bool IsBoostProgressBarEnabled { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/API/Rest/ModifyGuildParams.cs
+++ b/src/Discord.Net.Rest/API/Rest/ModifyGuildParams.cs
@@ -36,6 +36,6 @@ namespace Discord.API.Rest
         [JsonProperty("preferred_locale")]
         public string PreferredLocale { get; set; }
         [JsonProperty("premium_progress_bar_enabled")]
-        public bool IsBoostProgressBarEnabled { get; set; }
+        public Optional<bool> IsBoostProgressBarEnabled { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -37,7 +37,7 @@ namespace Discord.Rest
                 VerificationLevel = args.VerificationLevel,
                 ExplicitContentFilter = args.ExplicitContentFilter,
                 SystemChannelFlags = args.SystemChannelFlags,
-                IsBoostProgressBarEnabled = (bool)args.IsBoostProgressBarEnabled
+                IsBoostProgressBarEnabled = args.IsBoostProgressBarEnabled
             };
 
             if (args.AfkChannel.IsSpecified)

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -36,7 +36,8 @@ namespace Discord.Rest
                 Banner = args.Banner.IsSpecified ? args.Banner.Value?.ToModel() : Optional.Create<ImageModel?>(),
                 VerificationLevel = args.VerificationLevel,
                 ExplicitContentFilter = args.ExplicitContentFilter,
-                SystemChannelFlags = args.SystemChannelFlags
+                SystemChannelFlags = args.SystemChannelFlags,
+                IsBoostProgressBarEnabled = (bool)args.IsBoostProgressBarEnabled
             };
 
             if (args.AfkChannel.IsSpecified)

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -170,6 +170,8 @@ namespace Discord.Rest
                 ApproximateMemberCount = model.ApproximateMemberCount.Value;
             if (model.ApproximatePresenceCount.IsSpecified)
                 ApproximatePresenceCount = model.ApproximatePresenceCount.Value;
+            if (model.IsBoostProgressBarEnabled.IsSpecified)
+                IsBoostProgressBarEnabled = model.IsBoostProgressBarEnabled.Value;
 
             if (model.Emojis != null)
             {
@@ -1121,6 +1123,8 @@ namespace Discord.Rest
         IReadOnlyCollection<IRole> IGuild.Roles => Roles;
 
         IReadOnlyCollection<ICustomSticker> IGuild.Stickers => Stickers;
+        /// <inheritdoc />
+        public bool IsBoostProgressBarEnabled { get; private set; }
 
         /// <inheritdoc />
         async Task<IReadOnlyCollection<IBan>> IGuild.GetBansAsync(RequestOptions options)

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -88,6 +88,8 @@ namespace Discord.Rest
         public int? ApproximatePresenceCount { get; private set; }
         /// <inheritdoc />
         public NsfwLevel NsfwLevel { get; private set; }
+        /// <inheritdoc />
+        public bool IsBoostProgressBarEnabled { get; private set; }
 
         /// <inheritdoc />
         public CultureInfo PreferredCulture { get; private set; }
@@ -1123,8 +1125,6 @@ namespace Discord.Rest
         IReadOnlyCollection<IRole> IGuild.Roles => Roles;
 
         IReadOnlyCollection<ICustomSticker> IGuild.Stickers => Stickers;
-        /// <inheritdoc />
-        public bool IsBoostProgressBarEnabled { get; private set; }
 
         /// <inheritdoc />
         async Task<IReadOnlyCollection<IBan>> IGuild.GetBansAsync(RequestOptions options)

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketChannel.cs
@@ -31,7 +31,6 @@ namespace Discord.WebSocket
         /// <exception cref="InvalidOperationException">Unexpected channel type is created.</exception>
         internal static ISocketPrivateChannel CreatePrivate(DiscordSocketClient discord, ClientState state, Model model)
         {
-            Console.WriteLine(model.Type);
             return model.Type switch
             {
                 ChannelType.DM => SocketDMChannel.Create(discord, state, model),

--- a/src/Discord.Net.WebSocket/Entities/Channels/SocketChannel.cs
+++ b/src/Discord.Net.WebSocket/Entities/Channels/SocketChannel.cs
@@ -31,6 +31,7 @@ namespace Discord.WebSocket
         /// <exception cref="InvalidOperationException">Unexpected channel type is created.</exception>
         internal static ISocketPrivateChannel CreatePrivate(DiscordSocketClient discord, ClientState state, Model model)
         {
+            Console.WriteLine(model.Type);
             return model.Type switch
             {
                 ChannelType.DM => SocketDMChannel.Create(discord, state, model),

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -130,6 +130,8 @@ namespace Discord.WebSocket
         public CultureInfo PreferredCulture { get; private set; }
 
         /// <inheritdoc />
+        public bool IsBoostProgressBarEnabled { get; private set; }
+        /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <inheritdoc />
         public string IconUrl => CDN.GetGuildIconUrl(Id, IconId);
@@ -495,7 +497,8 @@ namespace Discord.WebSocket
                 MaxVideoChannelUsers = model.MaxVideoChannelUsers.Value;
             PreferredLocale = model.PreferredLocale;
             PreferredCulture = PreferredLocale == null ? null : new CultureInfo(PreferredLocale);
-
+            if (model.IsBoostProgressBarEnabled.IsSpecified)
+                IsBoostProgressBarEnabled = model.IsBoostProgressBarEnabled.Value;
             if (model.Emojis != null)
             {
                 var emojis = ImmutableArray.CreateBuilder<GuildEmote>(model.Emojis.Length);
@@ -1627,7 +1630,8 @@ namespace Discord.WebSocket
         int? IGuild.ApproximatePresenceCount => null;
         /// <inheritdoc />
         IReadOnlyCollection<ICustomSticker> IGuild.Stickers => Stickers;
-
+        /// <inheritdoc />
+        bool IGuild.IsBoostProgressBarEnabled => IsBoostProgressBarEnabled;
         /// <inheritdoc />
         async Task<IReadOnlyCollection<IBan>> IGuild.GetBansAsync(RequestOptions options)
             => await GetBansAsync(options).ConfigureAwait(false);

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -125,12 +125,11 @@ namespace Discord.WebSocket
         public int? MaxVideoChannelUsers { get; private set; }
         /// <inheritdoc />
         public NsfwLevel NsfwLevel { get; private set; }
-
         /// <inheritdoc />
         public CultureInfo PreferredCulture { get; private set; }
-
         /// <inheritdoc />
         public bool IsBoostProgressBarEnabled { get; private set; }
+
         /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -1631,8 +1631,6 @@ namespace Discord.WebSocket
         /// <inheritdoc />
         IReadOnlyCollection<ICustomSticker> IGuild.Stickers => Stickers;
         /// <inheritdoc />
-        bool IGuild.IsBoostProgressBarEnabled => IsBoostProgressBarEnabled;
-        /// <inheritdoc />
         async Task<IReadOnlyCollection<IBan>> IGuild.GetBansAsync(RequestOptions options)
             => await GetBansAsync(options).ConfigureAwait(false);
         /// <inheritdoc/>


### PR DESCRIPTION
# Support Guild Boost Progress Bars
Guild progress bars are added to discord and are documented at https://github.com/discord/discord-api-docs/pull/4001. This pr adds support for them to labs.
![image](https://user-images.githubusercontent.com/80918250/139112606-5bf74149-dd9d-4165-84fc-2a4784f9eb37.png)
![image](https://user-images.githubusercontent.com/80918250/139112613-453a2e82-b0b1-4895-ac54-1e7cdf833f95.png)
## closes 
#261 