### PR TITLE
Support Min and Max values on ApplicationCommandOptions

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
@@ -70,12 +70,12 @@ namespace Discord
         /// <summary>
         ///     The smallest number value the user can input.
         /// </summary>
-        public int? MinValue { get; set; }
+        public double? MinValue { get; set; }
 
         /// <summary>
         ///     The largest number value the user can input.
         /// </summary>
-        public int? MaxValue { get; set; }
+        public double? MaxValue { get; set; }
 
         /// <summary>
         ///     Gets or sets the choices for string and int types for the user to pick from.

--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
@@ -68,12 +68,12 @@ namespace Discord
         public bool Autocomplete { get; set; }
 
         /// <summary>
-        ///     The smallest number value the user can input.
+        ///     Gets or sets the smallest number value the user can input.
         /// </summary>
         public double? MinValue { get; set; }
 
         /// <summary>
-        ///     The largest number value the user can input.
+        ///     Gets or sets the largest number value the user can input.
         /// </summary>
         public double? MaxValue { get; set; }
 

--- a/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/ApplicationCommandOption.cs
@@ -66,6 +66,17 @@ namespace Discord
         ///     Gets or sets whether or not this option supports autocomplete.
         /// </summary>
         public bool Autocomplete { get; set; }
+
+        /// <summary>
+        ///     The smallest number value the user can input.
+        /// </summary>
+        public int? MinValue { get; set; }
+
+        /// <summary>
+        ///     The largest number value the user can input.
+        /// </summary>
+        public int? MaxValue { get; set; }
+
         /// <summary>
         ///     Gets or sets the choices for string and int types for the user to pick from.
         /// </summary>

--- a/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandOption.cs
@@ -33,6 +33,16 @@ namespace Discord
         bool? IsRequired { get; }
 
         /// <summary>
+        ///     The smallest number value the user can input.
+        /// </summary>
+        int? MinValue { get; }
+
+        /// <summary>
+        ///     The largest number value the user can input.
+        /// </summary>
+        int? MaxValue { get; }
+
+        /// <summary>
         ///     Choices for string and int types for the user to pick from.
         /// </summary>
         IReadOnlyCollection<IApplicationCommandOptionChoice> Choices { get; }

--- a/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandOption.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/IApplicationCommandOption.cs
@@ -35,12 +35,12 @@ namespace Discord
         /// <summary>
         ///     The smallest number value the user can input.
         /// </summary>
-        int? MinValue { get; }
+        double? MinValue { get; }
 
         /// <summary>
         ///     The largest number value the user can input.
         /// </summary>
-        int? MaxValue { get; }
+        double? MaxValue { get; }
 
         /// <summary>
         ///     Choices for string and int types for the user to pick from.

--- a/src/Discord.Net.Core/Entities/Interactions/Slash Commands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Slash Commands/SlashCommandBuilder.cs
@@ -155,10 +155,12 @@ namespace Discord
         /// <param name="options">The options of the option to add.</param>
         /// <param name="channelTypes">The allowed channel types for this option.</param>
         /// <param name="choices">The choices of this option.</param>
+        /// <param name="minValue">The smallest number value the user can input.</param>
+        /// <param name="maxValue">The largest number value the user can input.</param>
         /// <returns>The current builder.</returns>
         public SlashCommandBuilder AddOption(string name, ApplicationCommandOptionType type,
-           string description, bool? required = null, bool? isDefault = null, bool isAutocomplete = false, List<SlashCommandOptionBuilder> options = null,
-           List<ChannelType> channelTypes = null, params ApplicationCommandOptionChoiceProperties[] choices)
+           string description, bool? required = null, bool? isDefault = null, bool isAutocomplete = false, int? minValue = null, int? maxValue = null,
+           List<SlashCommandOptionBuilder> options = null, List<ChannelType> channelTypes = null, params ApplicationCommandOptionChoiceProperties[] choices)
         {
             // Make sure the name matches the requirements from discord
             Preconditions.NotNullOrEmpty(name, nameof(name));
@@ -189,7 +191,9 @@ namespace Discord
                 Type = type,
                 Autocomplete = isAutocomplete,
                 Choices = (choices ?? Array.Empty<ApplicationCommandOptionChoiceProperties>()).ToList(),
-                ChannelTypes = channelTypes
+                ChannelTypes = channelTypes,
+                MinValue = minValue,
+                MaxValue = maxValue,
             };
 
             return AddOption(option);
@@ -322,6 +326,16 @@ namespace Discord
         public bool Autocomplete { get; set; }
 
         /// <summary>
+        ///     The smallest number value the user can input.
+        /// </summary>
+        public int? MinValue { get; set; }
+
+        /// <summary>
+        ///     The largest number value the user can input.
+        /// </summary>
+        public int? MaxValue { get; set; }
+
+        /// <summary>
         ///     Gets or sets the choices for string and int types for the user to pick from.
         /// </summary>
         public List<ApplicationCommandOptionChoiceProperties> Choices { get; set; }
@@ -360,7 +374,9 @@ namespace Discord
                 Options = Options?.Count > 0 ? Options.Select(x => x.Build()).ToList() : new List<ApplicationCommandOptionProperties>(),
                 Choices = Choices,
                 Autocomplete = Autocomplete,
-                ChannelTypes = ChannelTypes
+                ChannelTypes = ChannelTypes,
+                MinValue = MinValue,
+                MaxValue = MaxValue
             };
         }
 
@@ -376,10 +392,12 @@ namespace Discord
         /// <param name="options">The options of the option to add.</param>
         /// <param name="channelTypes">The allowed channel types for this option.</param>
         /// <param name="choices">The choices of this option.</param>
+        /// <param name="minValue">The smallest number value the user can input.</param>
+        /// <param name="maxValue">The largest number value the user can input.</param>
         /// <returns>The current builder.</returns>
         public SlashCommandOptionBuilder AddOption(string name, ApplicationCommandOptionType type,
-           string description, bool? required = null, bool isDefault = false, bool isAutocomplete = false, List<SlashCommandOptionBuilder> options = null,
-           List<ChannelType> channelTypes = null, params ApplicationCommandOptionChoiceProperties[] choices)
+           string description, bool? required = null, bool isDefault = false, bool isAutocomplete = false, int? minValue = null, int? maxValue = null,
+           List<SlashCommandOptionBuilder> options = null, List<ChannelType> channelTypes = null, params ApplicationCommandOptionChoiceProperties[] choices)
         {
             // Make sure the name matches the requirements from discord
             Preconditions.NotNullOrEmpty(name, nameof(name));
@@ -407,6 +425,8 @@ namespace Discord
                 Required = required,
                 Default = isDefault,
                 Autocomplete = isAutocomplete,
+                MinValue = minValue,
+                MaxValue = maxValue,
                 Options = options,
                 Type = type,
                 Choices = (choices ?? Array.Empty<ApplicationCommandOptionChoiceProperties>()).ToList(),
@@ -558,6 +578,28 @@ namespace Discord
         public SlashCommandOptionBuilder WithAutocomplete(bool value)
         {
             Autocomplete = value;
+            return this;
+        }
+
+        /// <summary>
+        ///     Sets the current builders minValue field.
+        /// </summary>
+        /// <param name="value">The value to set.</param>
+        /// <returns>The current builder.</returns>
+        public SlashCommandOptionBuilder WithMinValue(int value)
+        {
+            MinValue = value;
+            return this;
+        }
+        
+        /// <summary>
+        ///     Sets the current builders maxValue field.
+        /// </summary>
+        /// <param name="value">The value to set.</param>
+        /// <returns>The current builder.</returns>
+        public SlashCommandOptionBuilder WithMaxValue(int value)
+        {
+            MaxValue = value;
             return this;
         }
 

--- a/src/Discord.Net.Core/Entities/Interactions/Slash Commands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Slash Commands/SlashCommandBuilder.cs
@@ -326,12 +326,12 @@ namespace Discord
         public bool Autocomplete { get; set; }
 
         /// <summary>
-        ///     The smallest number value the user can input.
+        ///     Gets or sets the smallest number value the user can input.
         /// </summary>
         public double? MinValue { get; set; }
 
         /// <summary>
-        ///     The largest number value the user can input.
+        ///     Gets or sets the largest number value the user can input.
         /// </summary>
         public double? MaxValue { get; set; }
 
@@ -589,7 +589,7 @@ namespace Discord
         }
 
         /// <summary>
-        ///     Sets the current builders minValue field.
+        ///     Sets the current builders min value field.
         /// </summary>
         /// <param name="value">The value to set.</param>
         /// <returns>The current builder.</returns>
@@ -600,7 +600,7 @@ namespace Discord
         }
         
         /// <summary>
-        ///     Sets the current builders maxValue field.
+        ///     Sets the current builders max value field.
         /// </summary>
         /// <param name="value">The value to set.</param>
         /// <returns>The current builder.</returns>

--- a/src/Discord.Net.Core/Entities/Interactions/Slash Commands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/Slash Commands/SlashCommandBuilder.cs
@@ -159,7 +159,7 @@ namespace Discord
         /// <param name="maxValue">The largest number value the user can input.</param>
         /// <returns>The current builder.</returns>
         public SlashCommandBuilder AddOption(string name, ApplicationCommandOptionType type,
-           string description, bool? required = null, bool? isDefault = null, bool isAutocomplete = false, int? minValue = null, int? maxValue = null,
+           string description, bool? required = null, bool? isDefault = null, bool isAutocomplete = false, double? minValue = null, double? maxValue = null,
            List<SlashCommandOptionBuilder> options = null, List<ChannelType> channelTypes = null, params ApplicationCommandOptionChoiceProperties[] choices)
         {
             // Make sure the name matches the requirements from discord
@@ -328,12 +328,12 @@ namespace Discord
         /// <summary>
         ///     The smallest number value the user can input.
         /// </summary>
-        public int? MinValue { get; set; }
+        public double? MinValue { get; set; }
 
         /// <summary>
         ///     The largest number value the user can input.
         /// </summary>
-        public int? MaxValue { get; set; }
+        public double? MaxValue { get; set; }
 
         /// <summary>
         ///     Gets or sets the choices for string and int types for the user to pick from.
@@ -357,12 +357,19 @@ namespace Discord
         public ApplicationCommandOptionProperties Build()
         {
             bool isSubType = Type == ApplicationCommandOptionType.SubCommandGroup;
+            bool isIntType = Type == ApplicationCommandOptionType.Integer;
 
             if (isSubType && (Options == null || !Options.Any()))
                 throw new InvalidOperationException("SubCommands/SubCommandGroups must have at least one option");
 
             if (!isSubType && Options != null && Options.Any() && Type != ApplicationCommandOptionType.SubCommand)
                 throw new InvalidOperationException($"Cannot have options on {Type} type");
+
+            if (isIntType && MinValue != null && MinValue % 1 != 0)
+                throw new InvalidOperationException("MinValue cannot have decimals on Integer command options.");
+
+            if (isIntType && MaxValue != null && MaxValue % 1 != 0)
+                throw new InvalidOperationException("MaxValue cannot have decimals on Integer command options.");
 
             return new ApplicationCommandOptionProperties
             {
@@ -396,7 +403,7 @@ namespace Discord
         /// <param name="maxValue">The largest number value the user can input.</param>
         /// <returns>The current builder.</returns>
         public SlashCommandOptionBuilder AddOption(string name, ApplicationCommandOptionType type,
-           string description, bool? required = null, bool isDefault = false, bool isAutocomplete = false, int? minValue = null, int? maxValue = null,
+           string description, bool? required = null, bool isDefault = false, bool isAutocomplete = false, double? minValue = null, double? maxValue = null,
            List<SlashCommandOptionBuilder> options = null, List<ChannelType> channelTypes = null, params ApplicationCommandOptionChoiceProperties[] choices)
         {
             // Make sure the name matches the requirements from discord
@@ -586,7 +593,7 @@ namespace Discord
         /// </summary>
         /// <param name="value">The value to set.</param>
         /// <returns>The current builder.</returns>
-        public SlashCommandOptionBuilder WithMinValue(int value)
+        public SlashCommandOptionBuilder WithMinValue(double value)
         {
             MinValue = value;
             return this;
@@ -597,7 +604,7 @@ namespace Discord
         /// </summary>
         /// <param name="value">The value to set.</param>
         /// <returns>The current builder.</returns>
-        public SlashCommandOptionBuilder WithMaxValue(int value)
+        public SlashCommandOptionBuilder WithMaxValue(double value)
         {
             MaxValue = value;
             return this;

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandOption.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandOption.cs
@@ -29,6 +29,12 @@ namespace Discord.API
         [JsonProperty("autocomplete")]
         public Optional<bool> Autocomplete { get; set; }
 
+        [JsonProperty("min_value")]
+        public Optional<int> MinValue { get; set; }
+
+        [JsonProperty("max_value")]
+        public Optional<int> MaxValue { get; set; }
+
         [JsonProperty("channel_types")]
         public Optional<ChannelType[]> ChannelTypes { get; set; }
 
@@ -48,6 +54,8 @@ namespace Discord.API
 
             Required = cmd.IsRequired ?? Optional<bool>.Unspecified;
             Default = cmd.IsDefault ?? Optional<bool>.Unspecified;
+            MinValue = cmd.MinValue ?? Optional<int>.Unspecified;
+            MaxValue = cmd.MaxValue ?? Optional<int>.Unspecified;
 
             Name = cmd.Name;
             Type = cmd.Type;
@@ -66,6 +74,8 @@ namespace Discord.API
             Required = option.Required ?? Optional<bool>.Unspecified;
 
             Default = option.Default ?? Optional<bool>.Unspecified;
+            MinValue = option.MinValue ?? Optional<int>.Unspecified;
+            MaxValue = option.MaxValue ?? Optional<int>.Unspecified;
 
             ChannelTypes = option.ChannelTypes?.ToArray() ?? Optional<ChannelType[]>.Unspecified;
 

--- a/src/Discord.Net.Rest/API/Common/ApplicationCommandOption.cs
+++ b/src/Discord.Net.Rest/API/Common/ApplicationCommandOption.cs
@@ -30,10 +30,10 @@ namespace Discord.API
         public Optional<bool> Autocomplete { get; set; }
 
         [JsonProperty("min_value")]
-        public Optional<int> MinValue { get; set; }
+        public Optional<double> MinValue { get; set; }
 
         [JsonProperty("max_value")]
-        public Optional<int> MaxValue { get; set; }
+        public Optional<double> MaxValue { get; set; }
 
         [JsonProperty("channel_types")]
         public Optional<ChannelType[]> ChannelTypes { get; set; }
@@ -54,8 +54,8 @@ namespace Discord.API
 
             Required = cmd.IsRequired ?? Optional<bool>.Unspecified;
             Default = cmd.IsDefault ?? Optional<bool>.Unspecified;
-            MinValue = cmd.MinValue ?? Optional<int>.Unspecified;
-            MaxValue = cmd.MaxValue ?? Optional<int>.Unspecified;
+            MinValue = cmd.MinValue ?? Optional<double>.Unspecified;
+            MaxValue = cmd.MaxValue ?? Optional<double>.Unspecified;
 
             Name = cmd.Name;
             Type = cmd.Type;
@@ -74,8 +74,8 @@ namespace Discord.API
             Required = option.Required ?? Optional<bool>.Unspecified;
 
             Default = option.Default ?? Optional<bool>.Unspecified;
-            MinValue = option.MinValue ?? Optional<int>.Unspecified;
-            MaxValue = option.MaxValue ?? Optional<int>.Unspecified;
+            MinValue = option.MinValue ?? Optional<double>.Unspecified;
+            MaxValue = option.MaxValue ?? Optional<double>.Unspecified;
 
             ChannelTypes = option.ChannelTypes?.ToArray() ?? Optional<ChannelType[]>.Unspecified;
 

--- a/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommandOption.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommandOption.cs
@@ -26,6 +26,12 @@ namespace Discord.Rest
         /// <inheritdoc/>
         public bool? IsRequired { get; private set; }
 
+        /// <inheritdoc/>
+        public int? MinValue { get; private set; }
+
+        /// <inheritdoc/>
+        public int? MaxValue { get; private set; }
+
         /// <summary>
         ///     A collection of <see cref="RestApplicationCommandChoice"/>'s for this command.
         /// </summary>
@@ -40,6 +46,7 @@ namespace Discord.Rest
         ///     The allowed channel types for this option.
         /// </summary>
         public IReadOnlyCollection<ChannelType> ChannelTypes { get; private set; }
+
 
         internal RestApplicationCommandOption() { }
 
@@ -61,6 +68,12 @@ namespace Discord.Rest
 
             if (model.Required.IsSpecified)
                 IsRequired = model.Required.Value;
+
+            if (model.MinValue.IsSpecified)
+                MinValue = model.MinValue.Value;
+
+            if (model.MaxValue.IsSpecified)
+                MaxValue = model.MaxValue.Value;
 
             Options = model.Options.IsSpecified
                 ? model.Options.Value.Select(Create).ToImmutableArray()

--- a/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommandOption.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/RestApplicationCommandOption.cs
@@ -27,10 +27,10 @@ namespace Discord.Rest
         public bool? IsRequired { get; private set; }
 
         /// <inheritdoc/>
-        public int? MinValue { get; private set; }
+        public double? MinValue { get; private set; }
 
         /// <inheritdoc/>
-        public int? MaxValue { get; private set; }
+        public double? MaxValue { get; private set; }
 
         /// <summary>
         ///     A collection of <see cref="RestApplicationCommandChoice"/>'s for this command.

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommandOption.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommandOption.cs
@@ -60,13 +60,13 @@ namespace Discord.WebSocket
             Type = model.Type;
             Description = model.Description;
 
-            IsDefault = model.Default.IsSpecified
-                ? model.Default.Value
-                : null;
+            IsDefault = model.Default.ToNullable();
 
-            IsRequired = model.Required.IsSpecified
-                ? model.Required.Value
-                : null;
+            IsRequired = model.Required.ToNullable();
+
+            MinValue = model.MinValue.ToNullable();
+
+            MaxValue = model.MaxValue.ToNullable();
 
             Choices = model.Choices.IsSpecified
                 ? model.Choices.Value.Select(SocketApplicationCommandChoice.Create).ToImmutableArray()
@@ -79,14 +79,6 @@ namespace Discord.WebSocket
             ChannelTypes = model.ChannelTypes.IsSpecified
                 ? model.ChannelTypes.Value.ToImmutableArray()
                 : ImmutableArray.Create<ChannelType>();
-
-            MinValue = model.MinValue.IsSpecified
-                ? model.MinValue.Value
-                : null;
-
-            MaxValue = model.MaxValue.IsSpecified
-                ? model.MaxValue.Value
-                : null;
         }
 
         IReadOnlyCollection<IApplicationCommandOptionChoice> IApplicationCommandOption.Choices => Choices;

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommandOption.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommandOption.cs
@@ -25,6 +25,12 @@ namespace Discord.WebSocket
         /// <inheritdoc/>
         public bool? IsRequired { get; private set; }
 
+        /// <inheritdoc/>
+        public int? MinValue { get; private set; }
+
+        /// <inheritdoc/>
+        public int? MaxValue { get; private set; }
+
         /// <summary>
         ///     Choices for string and int types for the user to pick from.
         /// </summary>
@@ -73,6 +79,14 @@ namespace Discord.WebSocket
             ChannelTypes = model.ChannelTypes.IsSpecified
                 ? model.ChannelTypes.Value.ToImmutableArray()
                 : ImmutableArray.Create<ChannelType>();
+
+            MinValue = model.MinValue.IsSpecified
+                ? model.MinValue.Value
+                : null;
+
+            MaxValue = model.MaxValue.IsSpecified
+                ? model.MaxValue.Value
+                : null;
         }
 
         IReadOnlyCollection<IApplicationCommandOptionChoice> IApplicationCommandOption.Choices => Choices;

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommandOption.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SocketBaseCommand/SocketApplicationCommandOption.cs
@@ -26,10 +26,10 @@ namespace Discord.WebSocket
         public bool? IsRequired { get; private set; }
 
         /// <inheritdoc/>
-        public int? MinValue { get; private set; }
+        public double? MinValue { get; private set; }
 
         /// <inheritdoc/>
-        public int? MaxValue { get; private set; }
+        public double? MaxValue { get; private set; }
 
         /// <summary>
         ///     Choices for string and int types for the user to pick from.


### PR DESCRIPTION
Adds `MinValue` and `MaxValue` to command options and command option builders.
resolves #268 