### PR TITLE
Automatically fix ordering of optional command options

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
@@ -378,8 +378,9 @@ namespace Discord
                 Default = Default,
                 Required = Required,
                 Type = Type,
-                Options = Options?.Count > 0 ? Options.OrderByDescending(x => x.Required ?? false)
-                    .Select(x => x.Build()).ToList() : new List<ApplicationCommandOptionProperties>(),
+                Options = Options?.Count > 0
+                    ? Options.OrderByDescending(x => x.Required ?? false).Select(x => x.Build()).ToList()
+                    : new List<ApplicationCommandOptionProperties>(),
                 Choices = Choices,
                 Autocomplete = Autocomplete,
                 ChannelTypes = ChannelTypes,

--- a/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/SlashCommands/SlashCommandBuilder.cs
@@ -100,7 +100,7 @@ namespace Discord
             {
                 var options = new List<ApplicationCommandOptionProperties>();
 
-                Options.ForEach(x => options.Add(x.Build()));
+                Options.OrderByDescending(x => x.Required ?? false).ToList().ForEach(x => options.Add(x.Build()));
 
                 props.Options = options;
             }
@@ -378,7 +378,8 @@ namespace Discord
                 Default = Default,
                 Required = Required,
                 Type = Type,
-                Options = Options?.Count > 0 ? Options.Select(x => x.Build()).ToList() : new List<ApplicationCommandOptionProperties>(),
+                Options = Options?.Count > 0 ? Options.OrderByDescending(x => x.Required ?? false)
+                    .Select(x => x.Build()).ToList() : new List<ApplicationCommandOptionProperties>(),
                 Choices = Choices,
                 Autocomplete = Autocomplete,
                 ChannelTypes = ChannelTypes,


### PR DESCRIPTION
Discord requires that optional command options be sent at the end of the command option list. This pr will automatically move non required command options to the end of the option list while preserving option order within the required/not required groups. 