### PR TITLE
Add Audit Log Data classes for Threads

### DIFF
--- a/src/Discord.Net.Rest/Entities/AuditLogs/AuditLogHelper.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/AuditLogHelper.cs
@@ -52,6 +52,7 @@ namespace Discord.Rest
             [ActionType.MessagePinned] = MessagePinAuditLogData.Create,
             [ActionType.MessageUnpinned] = MessageUnpinAuditLogData.Create,
 
+            [ActionType.ThreadCreate] = ThreadCreateAuditLogData.Create,
             [ActionType.ThreadDelete] = ThreadDeleteAuditLogData.Create,
         };
 

--- a/src/Discord.Net.Rest/Entities/AuditLogs/AuditLogHelper.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/AuditLogHelper.cs
@@ -52,6 +52,7 @@ namespace Discord.Rest
             [ActionType.MessagePinned] = MessagePinAuditLogData.Create,
             [ActionType.MessageUnpinned] = MessageUnpinAuditLogData.Create,
 
+            [ActionType.ThreadDelete] = ThreadDeleteAuditLogData.Create,
         };
 
         public static IAuditLogData CreateData(BaseDiscordClient discord, Model log, EntryModel entry)

--- a/src/Discord.Net.Rest/Entities/AuditLogs/AuditLogHelper.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/AuditLogHelper.cs
@@ -53,6 +53,7 @@ namespace Discord.Rest
             [ActionType.MessageUnpinned] = MessageUnpinAuditLogData.Create,
 
             [ActionType.ThreadCreate] = ThreadCreateAuditLogData.Create,
+            [ActionType.ThreadUpdate] = ThreadUpdateAuditLogData.Create,
             [ActionType.ThreadDelete] = ThreadDeleteAuditLogData.Create,
         };
 

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadCreateAuditLogData.cs
@@ -56,7 +56,7 @@ namespace Discord.Rest
         /// <returns>
         ///     A thread object representing the thread that was created if it still exists, otherwise returns <c>null</c>.
         /// </returns>
-        public IThreadChannel Thread;
+        public IThreadChannel Thread { get; }
 
         /// <summary>
         ///     Gets the snowflake ID of the thread.

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadCreateAuditLogData.cs
@@ -1,0 +1,104 @@
+using System.Linq;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    /// <summary>
+    ///     Contains a piece of audit log data related to a thread creation.
+    /// </summary>
+    public class ThreadCreateAuditLogData : IAuditLogData
+    {
+        private ThreadCreateAuditLogData(IThreadChannel thread, ulong id, string name, ThreadType type, bool archived,
+            ThreadArchiveDuration autoArchiveDuration, bool locked)
+        {
+            Thread = thread;
+            ThreadId = id;
+            ThreadName = name;
+            ThreadType = type;
+            IsArchived = archived;
+            AutoArchiveDuration = autoArchiveDuration;
+            IsLocked = locked;
+        }
+
+        internal static ThreadCreateAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            var id = entry.TargetId.Value;
+
+            var nameModel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "name");
+            var typeModel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "type");
+
+            var archivedModel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "archived");
+            var autoArchiveDurationModel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "auto_archive_duration");
+            var lockedModel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "locked");
+
+            var name = nameModel.OldValue.ToObject<string>(discord.ApiClient.Serializer);
+            var type = typeModel.OldValue.ToObject<ThreadType>(discord.ApiClient.Serializer);
+
+            var archived = archivedModel.OldValue.ToObject<bool>(discord.ApiClient.Serializer);
+            var autoArchiveDuration = autoArchiveDurationModel.OldValue.ToObject<ThreadArchiveDuration>(discord.ApiClient.Serializer);
+            var locked = lockedModel.OldValue.ToObject<bool>(discord.ApiClient.Serializer);
+
+            var threadInfo = log.Threads.FirstOrDefault(x => x.Id == id);
+            var threadChannel = threadInfo == null ? null : RestThreadChannel.Create(discord, (IGuild)null, threadInfo);
+
+            return new ThreadCreateAuditLogData(threadChannel, id, name, type, archived, autoArchiveDuration, locked);
+        }
+
+        // Doc Note: Corresponds to the *current* data
+
+        /// <summary>
+        ///     Gets the thread that was created if it still exists.
+        /// </summary>
+        /// <returns>
+        ///     A thread object representing the thread that was created if it still exists, otherwise returns <c>null</c>.
+        /// </returns>
+        public IThreadChannel Thread;
+
+        /// <summary>
+        ///     Gets the snowflake ID of the thread.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier for the thread.
+        /// </returns>
+        public ulong ThreadId { get; }
+        /// <summary>
+        ///     Gets the name of the thread.
+        /// </summary>
+        /// <returns>
+        ///     A string containing the name of the thread.
+        /// </returns>
+        public string ThreadName { get; }
+        /// <summary>
+        ///     Gets the type of the thread.
+        /// </summary>
+        /// <returns>
+        ///     The type of thread.
+        /// </returns>
+        public ThreadType ThreadType { get; }
+        /// <summary>
+        ///     Gets the value that indicates whether the thread is archived.
+        /// </summary>
+        /// <returns>
+        ///     <c>true</c> if this thread has the Archived flag enabled; otherwise <c>false</c>.
+        /// </returns>
+        public bool IsArchived { get; }
+        /// <summary>
+        ///     Gets the auto archive duration of the thread.
+        /// </summary>
+        /// <returns>
+        ///     The thread auto archive duration of the thread.
+        /// </returns>
+        public ThreadArchiveDuration AutoArchiveDuration { get; }
+        /// <summary>
+        ///     Gets the value that indicates whether the thread is locked.
+        /// </summary>
+        /// <returns>
+        ///     <c>true</c> if this thread has the Locked flag enabled; otherwise <c>false</c>.
+        /// </returns>
+        public bool IsLocked { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadCreateAuditLogData.cs
@@ -35,12 +35,12 @@ namespace Discord.Rest
             var autoArchiveDurationModel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "auto_archive_duration");
             var lockedModel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "locked");
 
-            var name = nameModel.OldValue.ToObject<string>(discord.ApiClient.Serializer);
-            var type = typeModel.OldValue.ToObject<ThreadType>(discord.ApiClient.Serializer);
+            var name = nameModel.NewValue.ToObject<string>(discord.ApiClient.Serializer);
+            var type = typeModel.NewValue.ToObject<ThreadType>(discord.ApiClient.Serializer);
 
-            var archived = archivedModel.OldValue.ToObject<bool>(discord.ApiClient.Serializer);
-            var autoArchiveDuration = autoArchiveDurationModel.OldValue.ToObject<ThreadArchiveDuration>(discord.ApiClient.Serializer);
-            var locked = lockedModel.OldValue.ToObject<bool>(discord.ApiClient.Serializer);
+            var archived = archivedModel.NewValue.ToObject<bool>(discord.ApiClient.Serializer);
+            var autoArchiveDuration = autoArchiveDurationModel.NewValue.ToObject<ThreadArchiveDuration>(discord.ApiClient.Serializer);
+            var locked = lockedModel.NewValue.ToObject<bool>(discord.ApiClient.Serializer);
 
             var threadInfo = log.Threads.FirstOrDefault(x => x.Id == id);
             var threadChannel = threadInfo == null ? null : RestThreadChannel.Create(discord, (IGuild)null, threadInfo);

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadCreateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadCreateAuditLogData.cs
@@ -57,7 +57,6 @@ namespace Discord.Rest
         ///     A thread object representing the thread that was created if it still exists, otherwise returns <c>null</c>.
         /// </returns>
         public IThreadChannel Thread { get; }
-
         /// <summary>
         ///     Gets the snowflake ID of the thread.
         /// </summary>

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadDeleteAuditLogData.cs
@@ -1,0 +1,90 @@
+using System.Linq;
+
+using Model = Discord.API.AuditLog;
+using EntryModel = Discord.API.AuditLogEntry;
+
+namespace Discord.Rest
+{
+    /// <summary>
+    ///     Contains a piece of audit log data related to a thread deletion.
+    /// </summary>
+    public class ThreadDeleteAuditLogData : IAuditLogData
+    {
+        private ThreadDeleteAuditLogData(ulong id, string name, ThreadType type, bool archived, ThreadArchiveDuration autoArchiveDuration, bool locked)
+        {
+            ThreadId = id;
+            ThreadName = name;
+            ThreadType = type;
+            IsArchived = archived;
+            AutoArchiveDuration = autoArchiveDuration;
+            IsLocked = locked;
+        }
+
+        internal static ThreadDeleteAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
+        {
+            var changes = entry.Changes;
+
+            var id = entry.TargetId.Value;
+            var thread = log.Threads.FirstOrDefault(x => x.Id == id);
+
+            var nameModel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "name");
+            var typeModel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "type");
+
+            var archivedModel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "archived");
+            var autoArchiveDurationModel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "auto_archive_duration");
+            var lockedModel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "locked");
+
+            var name = nameModel.OldValue.ToObject<string>(discord.ApiClient.Serializer);
+            var type = typeModel.OldValue.ToObject<ThreadType>(discord.ApiClient.Serializer);
+
+            var archived = archivedModel.OldValue.ToObject<bool>(discord.ApiClient.Serializer);
+            var autoArchiveDuration = autoArchiveDurationModel.OldValue.ToObject<ThreadArchiveDuration>(discord.ApiClient.Serializer);
+            var locked = lockedModel.OldValue.ToObject<bool>(discord.ApiClient.Serializer);
+
+            return new ThreadDeleteAuditLogData(id, name, type, archived, autoArchiveDuration, locked);
+        }
+
+        /// <summary>
+        ///     Gets the snowflake ID of the deleted thread.
+        /// </summary>
+        /// <returns>
+        ///     A <see cref="ulong"/> representing the snowflake identifier for the deleted thread.
+        /// </returns>
+        public ulong ThreadId { get; }
+        /// <summary>
+        ///     Gets the name of the deleted thread.
+        /// </summary>
+        /// <returns>
+        ///     A string containing the name of the deleted thread.
+        /// </returns>
+        public string ThreadName { get; }
+        /// <summary>
+        ///     Gets the type of the deleted thread.
+        /// </summary>
+        /// <returns>
+        ///     The type of thread that was deleted.
+        /// </returns>
+        public ThreadType ThreadType { get; }
+        /// <summary>
+        ///     Gets the value that indicates whether the deleted thread was archived.
+        /// </summary>
+        /// <returns>
+        ///     <c>true</c> if this thread had the Archived flag enabled; otherwise <c>false</c>.
+        /// </returns>
+        public bool IsArchived { get; }
+        /// <summary>
+        ///     Gets the thread auto archive duration of the deleted thread.
+        /// </summary>
+        /// <returns>
+        ///     The thread auto archive duration of the thread that was deleted.
+        /// </returns>
+        public ThreadArchiveDuration AutoArchiveDuration { get; }
+        /// <summary>
+        ///     Gets the value that indicates whether the deleted thread was locked.
+        /// </summary>
+        /// <returns>
+        ///     <c>true</c> if this thread had the Locked flag enabled; otherwise <c>false</c>.
+        /// </returns>
+        public bool IsLocked { get; }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadDeleteAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadDeleteAuditLogData.cs
@@ -10,7 +10,8 @@ namespace Discord.Rest
     /// </summary>
     public class ThreadDeleteAuditLogData : IAuditLogData
     {
-        private ThreadDeleteAuditLogData(ulong id, string name, ThreadType type, bool archived, ThreadArchiveDuration autoArchiveDuration, bool locked)
+        private ThreadDeleteAuditLogData(ulong id, string name, ThreadType type, bool archived,
+            ThreadArchiveDuration autoArchiveDuration, bool locked, int? rateLimit)
         {
             ThreadId = id;
             ThreadName = name;
@@ -18,6 +19,7 @@ namespace Discord.Rest
             IsArchived = archived;
             AutoArchiveDuration = autoArchiveDuration;
             IsLocked = locked;
+            SlowModeInterval = rateLimit;
         }
 
         internal static ThreadDeleteAuditLogData Create(BaseDiscordClient discord, Model log, EntryModel entry)
@@ -33,6 +35,7 @@ namespace Discord.Rest
             var archivedModel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "archived");
             var autoArchiveDurationModel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "auto_archive_duration");
             var lockedModel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "locked");
+            var rateLimitPerUserModel = changes.FirstOrDefault(x => x.ChangedProperty == "rate_limit_per_user");
 
             var name = nameModel.OldValue.ToObject<string>(discord.ApiClient.Serializer);
             var type = typeModel.OldValue.ToObject<ThreadType>(discord.ApiClient.Serializer);
@@ -40,8 +43,9 @@ namespace Discord.Rest
             var archived = archivedModel.OldValue.ToObject<bool>(discord.ApiClient.Serializer);
             var autoArchiveDuration = autoArchiveDurationModel.OldValue.ToObject<ThreadArchiveDuration>(discord.ApiClient.Serializer);
             var locked = lockedModel.OldValue.ToObject<bool>(discord.ApiClient.Serializer);
+            var rateLimit = rateLimitPerUserModel?.NewValue?.ToObject<int>(discord.ApiClient.Serializer);
 
-            return new ThreadDeleteAuditLogData(id, name, type, archived, autoArchiveDuration, locked);
+            return new ThreadDeleteAuditLogData(id, name, type, archived, autoArchiveDuration, locked, rateLimit);
         }
 
         /// <summary>
@@ -86,5 +90,14 @@ namespace Discord.Rest
         ///     <c>true</c> if this thread had the Locked flag enabled; otherwise <c>false</c>.
         /// </returns>
         public bool IsLocked { get; }
+        /// <summary>
+        ///     Gets the slow-mode delay of the deleted thread.
+        /// </summary>
+        /// <returns>
+        ///     An <see cref="int"/> representing the time in seconds required before the user can send another
+        ///     message; <c>0</c> if disabled.
+        ///     <c>null</c> if this is not mentioned in this entry.
+        /// </returns>
+        public int? SlowModeInterval { get; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadInfo.cs
@@ -1,0 +1,33 @@
+namespace Discord.Rest
+{
+    /// <summary>
+    ///     Represents information for a thread.
+    /// </summary>
+    public class ThreadInfo
+    {
+        /// <summary>
+        ///     Gets the name of the thread.
+        /// </summary>
+        public string Name { get; }
+        /// <summary>
+        ///     Gets the value that indicates whether the thread is archived.
+        /// </summary>
+        public bool IsArchived { get; }
+        /// <summary>
+        ///     Gets the auto archive duration of thread.
+        /// </summary>
+        public ThreadArchiveDuration AutoArchiveDuration { get; }
+        /// <summary>
+        ///     Gets the value that indicates whether the thread is locked.
+        /// </summary>
+        public bool IsLocked { get; }
+
+        internal ThreadInfo(string name, bool archived, ThreadArchiveDuration autoArchiveDuration, bool locked)
+        {
+            Name = name;
+            IsArchived = archived;
+            AutoArchiveDuration = autoArchiveDuration;
+            IsLocked = locked;
+        }
+    }
+}

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadInfo.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadInfo.cs
@@ -22,12 +22,18 @@ namespace Discord.Rest
         /// </summary>
         public bool IsLocked { get; }
 
-        internal ThreadInfo(string name, bool archived, ThreadArchiveDuration autoArchiveDuration, bool locked)
+        /// <summary>
+        ///     Gets the slow-mode delay of the ´thread.
+        /// </summary>
+        public int? SlowModeInterval { get; }
+
+        internal ThreadInfo(string name, bool archived, ThreadArchiveDuration autoArchiveDuration, bool locked, int? rateLimit)
         {
             Name = name;
             IsArchived = archived;
             AutoArchiveDuration = autoArchiveDuration;
             IsLocked = locked;
+            SlowModeInterval = rateLimit;
         }
     }
 }

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadUpdateAuditLogData.cs
@@ -30,20 +30,23 @@ namespace Discord.Rest
             var archivedModel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "archived");
             var autoArchiveDurationModel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "auto_archive_duration");
             var lockedModel = entry.Changes.FirstOrDefault(x => x.ChangedProperty == "locked");
+            var rateLimitPerUserModel = changes.FirstOrDefault(x => x.ChangedProperty == "rate_limit_per_user");
 
             var type = typeModel.OldValue.ToObject<ThreadType>(discord.ApiClient.Serializer);
 
-            var oldName = nameModel.NewValue.ToObject<string>(discord.ApiClient.Serializer);
-            var oldArchived = archivedModel.NewValue.ToObject<bool>(discord.ApiClient.Serializer);
-            var oldAutoArchiveDuration = autoArchiveDurationModel.NewValue.ToObject<ThreadArchiveDuration>(discord.ApiClient.Serializer);
-            var oldLocked = lockedModel.NewValue.ToObject<bool>(discord.ApiClient.Serializer);
-            var before = new ThreadInfo(oldName, oldArchived, oldAutoArchiveDuration, oldLocked);
+            var oldName = nameModel.OldValue.ToObject<string>(discord.ApiClient.Serializer);
+            var oldArchived = archivedModel.OldValue.ToObject<bool>(discord.ApiClient.Serializer);
+            var oldAutoArchiveDuration = autoArchiveDurationModel.OldValue.ToObject<ThreadArchiveDuration>(discord.ApiClient.Serializer);
+            var oldLocked = lockedModel.OldValue.ToObject<bool>(discord.ApiClient.Serializer);
+            var oldRateLimit = rateLimitPerUserModel?.OldValue?.ToObject<int>(discord.ApiClient.Serializer);
+            var before = new ThreadInfo(oldName, oldArchived, oldAutoArchiveDuration, oldLocked, oldRateLimit);
 
             var newName = nameModel.NewValue.ToObject<string>(discord.ApiClient.Serializer);
             var newArchived = archivedModel.NewValue.ToObject<bool>(discord.ApiClient.Serializer);
             var newAutoArchiveDuration = autoArchiveDurationModel.NewValue.ToObject<ThreadArchiveDuration>(discord.ApiClient.Serializer);
             var newLocked = lockedModel.NewValue.ToObject<bool>(discord.ApiClient.Serializer);
-            var after = new ThreadInfo(newName, newArchived, newAutoArchiveDuration, newLocked);
+            var newRateLimit = rateLimitPerUserModel?.NewValue?.ToObject<int>(discord.ApiClient.Serializer);
+            var after = new ThreadInfo(newName, newArchived, newAutoArchiveDuration, newLocked, newRateLimit);
 
             var threadInfo = log.Threads.FirstOrDefault(x => x.Id == id);
             var threadChannel = threadInfo == null ? null : RestThreadChannel.Create(discord, (IGuild)null, threadInfo);

--- a/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadUpdateAuditLogData.cs
+++ b/src/Discord.Net.Rest/Entities/AuditLogs/DataTypes/ThreadUpdateAuditLogData.cs
@@ -1,9 +1,7 @@
-using System.Collections.Generic;
 using System.Linq;
 
 using Model = Discord.API.AuditLog;
 using EntryModel = Discord.API.AuditLogEntry;
-using Discord.API;
 
 namespace Discord.Rest
 {


### PR DESCRIPTION
# Summary
Audit logs can contain entries about thread creation, modification and deletion.
This has not yet been available in the library.

This PR just adds those 3 in.
