### PR TITLE
Make autocomplete log virtual

### DIFF
--- a/src/Discord.Net.Interactions/AutocompleteHandlers/AutocompleteHandler.cs
+++ b/src/Discord.Net.Interactions/AutocompleteHandlers/AutocompleteHandler.cs
@@ -19,7 +19,11 @@ namespace Discord.Interactions
         public abstract Task<AutocompletionResult> GenerateSuggestionsAsync(IInteractionContext context, IAutocompleteInteraction autocompleteInteraction, IParameterInfo parameter,
             IServiceProvider services);
 
-        protected abstract string GetLogString(IInteractionContext context);
+        protected virtual string GetLogString(IInteractionContext context)
+        {
+            var interaction = (context.Interaction as IAutocompleteInteraction);
+            return $"{interaction.Data.CommandName}: {interaction.Data.Current.Name} Autocomplete";
+        }
 
         /// <inheritdoc/>
         public async Task<IResult> ExecuteAsync(IInteractionContext context, IAutocompleteInteraction autocompleteInteraction, IParameterInfo parameter,


### PR DESCRIPTION
## Summary
This PR makes the `GetLogString` virtual by adding a default of `CommandName: ParameterName` as the default log.

### Motivation
Adding additional methods a developer has to implement isn't always the solution, I don't see why it has to be abstract.