### PR TITLE
correct the number of allowed autocomplete choices

### DIFF
--- a/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/InteractionHelper.cs
@@ -427,7 +427,7 @@ namespace Discord.Rest
         {
             result ??= Array.Empty<AutocompleteResult>();
 
-            Preconditions.AtMost(result.Count(), 20, nameof(result), "A maximum of 20 choices are allowed!");
+            Preconditions.AtMost(result.Count(), 25, nameof(result), "A maximum of 25 choices are allowed!");
 
             var apiArgs = new InteractionResponse
             {

--- a/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestAutocompleteInteraction.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/SlashCommands/RestAutocompleteInteraction.cs
@@ -46,7 +46,7 @@ namespace Discord.Rest
         /// <param name="result">
         ///     The set of choices for the user to pick from.
         ///     <remarks>
-        ///         A max of 20 choices are allowed. Passing <see langword="null"/> for this argument will show the executing user that
+        ///         A max of 25 choices are allowed. Passing <see langword="null"/> for this argument will show the executing user that
         ///         there is no choices for their autocompleted input.
         ///     </remarks>
         /// </param>
@@ -93,7 +93,7 @@ namespace Discord.Rest
         /// <param name="result">
         ///  The set of choices for the user to pick from.
         ///     <remarks>
-        ///         A max of 20 choices are allowed. Passing <see langword="null"/> for this argument will show the executing user that
+        ///         A max of 25 choices are allowed. Passing <see langword="null"/> for this argument will show the executing user that
         ///         there is no choices for their autocompleted input.
         ///     </remarks>
         /// </param>

--- a/src/Discord.Net.WebSocket/Entities/Interaction/SlashCommands/SocketAutocompleteInteraction.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/SlashCommands/SocketAutocompleteInteraction.cs
@@ -45,7 +45,7 @@ namespace Discord.WebSocket
         /// <param name="result">
         ///     The set of choices for the user to pick from.
         ///     <remarks>
-        ///         A max of 20 choices are allowed. Passing <see langword="null"/> for this argument will show the executing user that
+        ///         A max of 25 choices are allowed. Passing <see langword="null"/> for this argument will show the executing user that
         ///         there is no choices for their autocompleted input.
         ///     </remarks>
         /// </param>
@@ -80,7 +80,7 @@ namespace Discord.WebSocket
         /// <param name="result">
         ///  The set of choices for the user to pick from.
         ///     <remarks>
-        ///         A max of 20 choices are allowed. Passing <see langword="null"/> for this argument will show the executing user that
+        ///         A max of 25 choices are allowed. Passing <see langword="null"/> for this argument will show the executing user that
         ///         there is no choices for their autocompleted input.
         ///     </remarks>
         /// </param>


### PR DESCRIPTION
25 choices are supported.
autocomplete options follows the [Application Command Option Structure's "choices" property](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)