### PR TITLE
Fix Autocomplete Command Traversal

### DIFF
--- a/src/Discord.Net.Interactions/Extensions/WebSocketExtensions.cs
+++ b/src/Discord.Net.Interactions/Extensions/WebSocketExtensions.cs
@@ -13,7 +13,7 @@ namespace Discord.WebSocket
         /// <returns>
         ///     The name of the executed command and its parents in hierarchical order.
         /// </returns>
-        public static string[] GetCommandKeywords(this IApplicationCommandInteractionData data)
+        public static IList<string> GetCommandKeywords(this IApplicationCommandInteractionData data)
         {
             var keywords = new List<string> { data.Name };
 
@@ -25,7 +25,7 @@ namespace Discord.WebSocket
                 child = child.Options?.ElementAtOrDefault(0);
             }
 
-            return keywords.ToArray();
+            return keywords;
         }
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace Discord.WebSocket
         /// <returns>
         ///     The name of the executed command and its parents in hierarchical order.
         /// </returns>
-        public static string[] GetCommandKeywords(this IAutocompleteInteractionData data)
+        public static IList<string> GetCommandKeywords(this IAutocompleteInteractionData data)
         {
             var keywords = new List<string> { data.CommandName };
 
@@ -47,7 +47,7 @@ namespace Discord.WebSocket
             if (subcommand is not null)
                 keywords.Add(subcommand.Name);
 
-            return keywords.ToArray();
+            return keywords;
         }
     }
 }

--- a/src/Discord.Net.Interactions/Info/Commands/AutocompleteCommandInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Commands/AutocompleteCommandInfo.cs
@@ -64,23 +64,26 @@ namespace Discord.Interactions
                 return $"Autocomplete Command: \"{base.ToString()}\" for {context.User} in {context.Channel}";
         }
 
-        internal string[] GetCommandKeywords()
+        internal IList<string> GetCommandKeywords()
         {
             var keywords = new List<string>() { ParameterName, CommandName };
 
-            var currentParent = Module;
-
-            while (currentParent != null)
+            if(!IgnoreGroupNames)
             {
-                if (!string.IsNullOrEmpty(currentParent.SlashGroupName))
-                    keywords.Add(currentParent.SlashGroupName);
+                var currentParent = Module;
 
-                currentParent = currentParent.Parent;
+                while (currentParent != null)
+                {
+                    if (!string.IsNullOrEmpty(currentParent.SlashGroupName))
+                        keywords.Add(currentParent.SlashGroupName);
+
+                    currentParent = currentParent.Parent;
+                }
             }
 
             keywords.Reverse();
 
-            return keywords.ToArray();
+            return keywords;
         }
     }
 }

--- a/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
@@ -40,7 +40,7 @@ namespace Discord.Interactions
         /// <summary>
         ///     Gets whether this parameter is configured for Autocomplete Interactions.
         /// </summary>
-        public bool IsAutocomplete => AutocompleteHandler is not null;
+        public bool IsAutocomplete { get; }
 
         /// <summary>
         ///     Gets the Discord option type this parameter represents.
@@ -64,6 +64,7 @@ namespace Discord.Interactions
             Description = builder.Description;
             MaxValue = builder.MaxValue;
             MinValue = builder.MinValue;
+            IsAutocomplete = builder.Autocomplete;
             Choices = builder.Choices.ToImmutableArray();
             ChannelTypes = builder.ChannelTypes.ToImmutableArray();
         }

--- a/src/Discord.Net.Interactions/InteractionService.cs
+++ b/src/Discord.Net.Interactions/InteractionService.cs
@@ -505,7 +505,7 @@ namespace Discord.Interactions
                 _componentCommandMap.AddCommand(interaction, interaction.IgnoreGroupNames);
 
             foreach (var command in module.AutocompleteCommands)
-                _autocompleteCommandMap.AddCommand(command, command.IgnoreGroupNames);
+                _autocompleteCommandMap.AddCommand(command.GetCommandKeywords(), command);
 
             foreach (var subModule in module.SubModules)
                 LoadModuleInternal(subModule);
@@ -675,10 +675,12 @@ namespace Discord.Interactions
                 {
                     var parameter = autocompleteHandlerResult.Command.Parameters.FirstOrDefault(x => string.Equals(x.Name, interaction.Data.Current.Name, StringComparison.Ordinal));
 
-                    if(parameter is not null)
+                    if(parameter?.AutocompleteHandler is not null)
                         return await parameter.AutocompleteHandler.ExecuteAsync(context, interaction, parameter, services).ConfigureAwait(false);
                 }
             }
+
+            keywords.Add(interaction.Data.Current.Name);
 
             var commandResult = _autocompleteCommandMap.GetCommand(keywords);
 

--- a/src/Discord.Net.Interactions/Map/CommandMap.cs
+++ b/src/Discord.Net.Interactions/Map/CommandMap.cs
@@ -35,14 +35,14 @@ namespace Discord.Interactions
             _root.AddCommand(key, 0, command);
         }
 
-        public void AddCommand(string[] input, T command)
+        public void AddCommand(IList<string> input, T command)
         {
             _root.AddCommand(input, 0, command);
         }
 
         public void RemoveCommand(T command)
         {
-            string[] key = ParseCommandName(command);
+            var key = ParseCommandName(command);
 
             _root.RemoveCommand(key, 0);
         }
@@ -55,17 +55,17 @@ namespace Discord.Interactions
                 return GetCommand(new string[] { input });
         }
 
-        public SearchResult<T> GetCommand(string[] input) =>
+        public SearchResult<T> GetCommand(IList<string> input) =>
             _root.GetCommand(input, 0);
 
         private void AddCommand(T command)
         {
-            string[] key = ParseCommandName(command);
+            var key = ParseCommandName(command);
 
             _root.AddCommand(key, 0, command);
         }
 
-        private string[] ParseCommandName(T command)
+        private IList<string> ParseCommandName(T command)
         {
             var keywords = new List<string>() { command.Name };
 
@@ -81,7 +81,7 @@ namespace Discord.Interactions
 
             keywords.Reverse();
 
-            return keywords.ToArray();
+            return keywords;
         }
     }
 }

--- a/src/Discord.Net.Interactions/Map/CommandMapNode.cs
+++ b/src/Discord.Net.Interactions/Map/CommandMapNode.cs
@@ -31,9 +31,9 @@ namespace Discord.Interactions
                 _wildCardStr = wildCardExp;
         }
 
-        public void AddCommand (string[] keywords, int index, T commandInfo)
+        public void AddCommand (IList<string> keywords, int index, T commandInfo)
         {
-            if (keywords.Length == index + 1)
+            if (keywords.Count == index + 1)
             {
                 if (commandInfo.SupportsWildCards && commandInfo.Name.Contains(_wildCardStr))
                 {
@@ -46,7 +46,7 @@ namespace Discord.Interactions
                 }
                 else
                 {
-                    if (!_commands.TryAdd(commandInfo.Name, commandInfo))
+                    if (!_commands.TryAdd(keywords[index], commandInfo))
                         throw new InvalidOperationException($"A {typeof(T).FullName} already exists with the same name: {string.Join(" ", keywords)}");
                 }
             }
@@ -57,9 +57,9 @@ namespace Discord.Interactions
             }
         }
 
-        public bool RemoveCommand (string[] keywords, int index)
+        public bool RemoveCommand (IList<string> keywords, int index)
         {
-            if (keywords.Length == index + 1)
+            if (keywords.Count == index + 1)
                 return _commands.TryRemove(keywords[index], out var _);
             else
             {
@@ -70,11 +70,11 @@ namespace Discord.Interactions
             }
         }
 
-        public SearchResult<T> GetCommand (string[] keywords, int index)
+        public SearchResult<T> GetCommand (IList<string> keywords, int index)
         {
             string name = string.Join(" ", keywords);
 
-            if (keywords.Length == index + 1)
+            if (keywords.Count == index + 1)
             {
                 if (_commands.TryGetValue(keywords[index], out var cmd))
                     return SearchResult<T>.FromSuccess(name, cmd);


### PR DESCRIPTION
This PR fixes the autocomplete command traversal problem and replaces string arrays used in the command maps with IList<string> to remove the unnecessary `ToArray()` method calls and give devs access to a variable sized container.