### PR TITLE
Fix Module Preconditions

### DIFF
--- a/src/Discord.Net.Interactions/Info/ModuleInfo.cs
+++ b/src/Discord.Net.Interactions/Info/ModuleInfo.cs
@@ -118,7 +118,7 @@ namespace Discord.Interactions
             IsTopLevelGroup = CheckTopLevel(parent);
             DontAutoRegister = builder.DontAutoRegister;
 
-            GroupedPreconditions = builder.Preconditions.ToLookup(x => x.Group, x => x, StringComparer.Ordinal);
+            GroupedPreconditions = Preconditions.ToLookup(x => x.Group, x => x, StringComparer.Ordinal);
         }
 
         private IEnumerable<ModuleInfo> BuildSubModules (ModuleBuilder builder, InteractionService commandService, IServiceProvider services)
@@ -189,7 +189,7 @@ namespace Discord.Interactions
         {
             var preconditions = new List<PreconditionAttribute>();
 
-            var parent = builder.Parent;
+            var parent = builder;
 
             while (parent != null)
             {

--- a/src/Discord.Net.Interactions/Info/ModuleInfo.cs
+++ b/src/Discord.Net.Interactions/Info/ModuleInfo.cs
@@ -189,7 +189,7 @@ namespace Discord.Interactions
         {
             var preconditions = new List<PreconditionAttribute>();
 
-            var parent = builder.Parent;
+            var parent = builder;
 
             while (parent != null)
             {


### PR DESCRIPTION
This PR adds the missing step for adding building and adding the preconditions of the base module class. This bug doesnt affect the precondition checks during the execution step.