### PR TITLE
Trim SlashCommandInfo.ToString() to remove unncecessary spaces

### DIFF
--- a/src/Discord.Net.Interactions/Info/Commands/CommandInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Commands/CommandInfo.cs
@@ -241,7 +241,7 @@ namespace Discord.Interactions
             }
             builder.AppendFormat(" {0}", Name);
 
-            return builder.ToString();
+            return builder.ToString().Trim();
         }
     }
 }


### PR DESCRIPTION
Currently `SlashCommandInfo.ToString()` includes unnecessary spaces at the start of the string.

E.G `$"Slash command executed: /{info}"` -> `/ dev test`
With `.Trim()` it looks like this `/dev test`

This is an extremely simple change and should not break anything from the few tests I've done