### PR TITLE
Ensure User Left Event

### DIFF
--- a/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
+++ b/src/Discord.Net.WebSocket/BaseSocketClient.Events.cs
@@ -424,12 +424,12 @@ namespace Discord.WebSocket
         }
         internal readonly AsyncEvent<Func<SocketGuildUser, Task>> _userJoinedEvent = new AsyncEvent<Func<SocketGuildUser, Task>>();
         /// <summary> Fired when a user leaves a guild. </summary>
-        public event Func<SocketGuildUser, Task> UserLeft
+        public event Func<SocketUser, Task> UserLeft
         {
             add { _userLeftEvent.Add(value); }
             remove { _userLeftEvent.Remove(value); }
         }
-        internal readonly AsyncEvent<Func<SocketGuildUser, Task>> _userLeftEvent = new AsyncEvent<Func<SocketGuildUser, Task>>();
+        internal readonly AsyncEvent<Func<SocketUser, Task>> _userLeftEvent = new AsyncEvent<Func<SocketUser, Task>>();
         /// <summary> Fired when a user is banned from a guild. </summary>
         public event Func<SocketUser, SocketGuild, Task> UserBanned
         {

--- a/src/Discord.Net.WebSocket/DiscordSocketClient.cs
+++ b/src/Discord.Net.WebSocket/DiscordSocketClient.cs
@@ -1300,7 +1300,7 @@ namespace Discord.WebSocket
                                     var guild = State.GetGuild(data.GuildId);
                                     if (guild != null)
                                     {
-                                        var user = guild.RemoveUser(data.User.Id);
+                                        SocketUser user = guild.RemoveUser(data.User.Id);
                                         guild.MemberCount--;
 
                                         if (!guild.IsSynced)
@@ -1309,16 +1309,10 @@ namespace Discord.WebSocket
                                             return;
                                         }
 
-                                        if (user != null)
-                                            await TimedInvokeAsync(_userLeftEvent, nameof(UserLeft), user).ConfigureAwait(false);
-                                        else
-                                        {
-                                            if (!guild.HasAllMembers)
-                                                await IncompleteGuildUserAsync(type, data.User.Id, data.GuildId).ConfigureAwait(false);
-                                            else
-                                                await UnknownGuildUserAsync(type, data.User.Id, data.GuildId).ConfigureAwait(false);
-                                            return;
-                                        }
+                                        if(user == null)
+                                            user = SocketGlobalUser.Create(this, State, data.User);
+
+                                        await TimedInvokeAsync(_userLeftEvent, nameof(UserLeft), user).ConfigureAwait(false);
                                     }
                                     else
                                     {


### PR DESCRIPTION
## Summary

This PR makes the `UserLeft` event fire even if the guild member isn't cached.

Since the [Guild Member Remove](https://discord.com/developers/docs/topics/gateway#guild-member-remove-guild-member-remove-event-fields) event contains a `user` model we can create a global user when the guild user isn't cached. For this to work we would change the `UserLeft` events parameter to a `SocketUser` allowing both `SocketGuildUser`s and `SocketGlobalUser`s to be passed into the event.