### PR TITLE
Remove DeleteUnknownSlashCommandAck from Interaction Service

### DIFF
--- a/src/Discord.Net.Interactions/InteractionService.cs
+++ b/src/Discord.Net.Interactions/InteractionService.cs
@@ -67,7 +67,7 @@ namespace Discord.Interactions
         internal readonly LogManager _logManager;
         internal readonly Func<DiscordRestClient> _getRestClient;
 
-        internal readonly bool _throwOnError, _deleteUnkownSlashCommandAck, _useCompiledLambda, _enableAutocompleteHandlers;
+        internal readonly bool _throwOnError, _useCompiledLambda, _enableAutocompleteHandlers;
         internal readonly string _wildCardExp;
         internal readonly RunMode _runMode;
         internal readonly RestResponseCallback _restResponseCallback;
@@ -153,7 +153,6 @@ namespace Discord.Interactions
                 throw new InvalidOperationException($"RunMode cannot be set to {RunMode.Default}");
 
             _throwOnError = config.ThrowOnError;
-            _deleteUnkownSlashCommandAck = config.DeleteUnknownSlashCommandAck;
             _wildCardExp = config.WildCardExpression;
             _useCompiledLambda = config.UseCompiledLambda;
             _enableAutocompleteHandlers = config.EnableAutocompleteHandlers;
@@ -619,12 +618,6 @@ namespace Discord.Interactions
             if (!result.IsSuccess)
             {
                 await _cmdLogger.DebugAsync($"Unknown slash command, skipping execution ({string.Join(" ", keywords).ToUpper()})");
-
-                if (_deleteUnkownSlashCommandAck)
-                {
-                    var response = await context.Interaction.GetOriginalResponseAsync().ConfigureAwait(false);
-                    await response.DeleteAsync().ConfigureAwait(false);
-                }
 
                 await _slashCommandExecutedEvent.InvokeAsync(null, context, result).ConfigureAwait(false);
                 return result;

--- a/src/Discord.Net.Interactions/InteractionServiceConfig.cs
+++ b/src/Discord.Net.Interactions/InteractionServiceConfig.cs
@@ -34,11 +34,6 @@ namespace Discord.Interactions
         public string WildCardExpression { get; set; }
 
         /// <summary>
-        ///     Gets or sets the option to delete Slash Command acknowledgements if no Slash Command handler is found in the <see cref="InteractionService"/>.
-        /// </summary>
-        public bool DeleteUnknownSlashCommandAck { get; set; } = true;
-
-        /// <summary>
         ///     Gets or sets the option to use compiled lambda expressions to create module instances and execute commands. This method improves performance at the cost of memory.
         /// </summary>
         public bool UseCompiledLambda { get; set; } = false;


### PR DESCRIPTION
This PR removes the now unnecessary `DeleteUnknownSlashCommandAck` option from the Interaction Service, which was originally designed to work with the deprecated `AlwaysAcknowledgeInteractions` feature.