### PR TITLE
fix: unclear parameter naming for MessageCommand

### DIFF
--- a/docs/guides/interactions_framework/intro.md
+++ b/docs/guides/interactions_framework/intro.md
@@ -192,7 +192,7 @@ A valid Message Command must have the following structure:
 
 ```csharp
 [MessageCommand("Bookmark")]
-public async Task Bookmark(IMessage user)
+public async Task Bookmark(IMessage message)
 {
     ...
 }


### PR DESCRIPTION
Fixes a minor copy and paste typo in the MessageCommand documentation.
