### PR TITLE
Interaction Service Complex Parameters

### DIFF
--- a/src/Discord.Net.Interactions/Attributes/ComplexParameterAttribute.cs
+++ b/src/Discord.Net.Interactions/Attributes/ComplexParameterAttribute.cs
@@ -8,5 +8,23 @@ namespace Discord.Interactions
     [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
     public class ComplexParameterAttribute : Attribute
     {
+        /// <summary>
+        ///     Gets the parameter array of the constructor method that should be prioritized.
+        /// </summary>
+        public Type[] PrioritizedCtorSignature { get; }
+
+        /// <summary>
+        ///     Registers a slash command parameter as a complex parameter.
+        /// </summary>
+        public ComplexParameterAttribute() { }
+
+        /// <summary>
+        ///     Registers a slash command parameter as a complex parameter with a specified constructor signature.
+        /// </summary>
+        /// <param name="types">Type array of the preferred constructor parameters.</param>
+        public ComplexParameterAttribute(Type[] types)
+        {
+            PrioritizedCtorSignature= types;
+        }
     }
 }

--- a/src/Discord.Net.Interactions/Attributes/ComplexParameterAttribute.cs
+++ b/src/Discord.Net.Interactions/Attributes/ComplexParameterAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Discord.Interactions
+{
+    /// <summary>
+    ///     Registers a parameter as a complex parameter.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = true)]
+    public class ComplexParameterAttribute : Attribute
+    {
+    }
+}

--- a/src/Discord.Net.Interactions/Attributes/ComplexParameterAttribute.cs
+++ b/src/Discord.Net.Interactions/Attributes/ComplexParameterAttribute.cs
@@ -24,7 +24,7 @@ namespace Discord.Interactions
         /// <param name="types">Type array of the preferred constructor parameters.</param>
         public ComplexParameterAttribute(Type[] types)
         {
-            PrioritizedCtorSignature= types;
+            PrioritizedCtorSignature = types;
         }
     }
 }

--- a/src/Discord.Net.Interactions/Attributes/ComplexParameterCtorAttribute.cs
+++ b/src/Discord.Net.Interactions/Attributes/ComplexParameterCtorAttribute.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Discord.Interactions
+{
+    /// <summary>
+    ///     Tag a type constructor as the preferred Complex command constructor.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = true)]
+    public class ComplexParameterCtorAttribute : Attribute { }
+}

--- a/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
@@ -417,42 +417,6 @@ namespace Discord.Interactions.Builders
             builder.Name = Regex.Replace(builder.Name, "(?<=[a-z])(?=[A-Z])", "-").ToLower();
         }
 
-        private static ConstructorInfo GetComplexParameterConstructor(TypeInfo typeInfo, ComplexParameterAttribute complexParameter)
-        {
-            var ctors = typeInfo.GetConstructors();
-
-            if(ctors.Length == 0)
-                throw new InvalidOperationException($"No constructor found for \"{typeInfo.FullName}\".");
-
-            if (complexParameter.PrioritizedCtorSignature is not null)
-            {
-                var ctor = typeInfo.GetConstructor(complexParameter.PrioritizedCtorSignature);
-
-                if (ctor is null)
-                    throw new InvalidOperationException($"No constructor was found with the signature: {string.Join(",", complexParameter.PrioritizedCtorSignature.Select(x => x.Name))}");
-
-                return ctor;
-            }
-
-            var prioritizedCtors = ctors.Where(x => x.IsDefined(typeof(ComplexParameterCtorAttribute), true));
-
-            switch (prioritizedCtors.Count())
-            {
-                case > 1:
-                    throw new InvalidOperationException($"{nameof(ComplexParameterCtorAttribute)} can only be used once in a type.");
-                case 1:
-                    return prioritizedCtors.First();
-            }
-
-            switch (ctors.Length)
-            {
-                case > 1:
-                    throw new InvalidOperationException($"Multiple constructors found for \"{typeInfo.FullName}\".");
-                default:
-                    return ctors.First();
-            }
-        }
-
         private static void BuildParameter (CommandParameterBuilder builder, ParameterInfo paramInfo)
         {
             var attributes = paramInfo.GetCustomAttributes();
@@ -519,6 +483,42 @@ namespace Discord.Interactions.Builders
                 !methodInfo.IsStatic &&
                 !methodInfo.IsGenericMethod &&
                 methodInfo.GetParameters().Length == 0;
+        }
+
+        private static ConstructorInfo GetComplexParameterConstructor(TypeInfo typeInfo, ComplexParameterAttribute complexParameter)
+        {
+            var ctors = typeInfo.GetConstructors();
+
+            if (ctors.Length == 0)
+                throw new InvalidOperationException($"No constructor found for \"{typeInfo.FullName}\".");
+
+            if (complexParameter.PrioritizedCtorSignature is not null)
+            {
+                var ctor = typeInfo.GetConstructor(complexParameter.PrioritizedCtorSignature);
+
+                if (ctor is null)
+                    throw new InvalidOperationException($"No constructor was found with the signature: {string.Join(",", complexParameter.PrioritizedCtorSignature.Select(x => x.Name))}");
+
+                return ctor;
+            }
+
+            var prioritizedCtors = ctors.Where(x => x.IsDefined(typeof(ComplexParameterCtorAttribute), true));
+
+            switch (prioritizedCtors.Count())
+            {
+                case > 1:
+                    throw new InvalidOperationException($"{nameof(ComplexParameterCtorAttribute)} can only be used once in a type.");
+                case 1:
+                    return prioritizedCtors.First();
+            }
+
+            switch (ctors.Length)
+            {
+                case > 1:
+                    throw new InvalidOperationException($"Multiple constructors found for \"{typeInfo.FullName}\".");
+                default:
+                    return ctors.First();
+            }
         }
     }
 }

--- a/src/Discord.Net.Interactions/Builders/Parameters/SlashCommandParameterBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/Parameters/SlashCommandParameterBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Discord.Interactions.Builders
 {
@@ -195,12 +196,19 @@ namespace Discord.Interactions.Builders
         {
             SlashCommandParameterBuilder builder = new(Command);
             configure(builder);
+
+            if(builder.IsComplexParameter)
+                throw new InvalidOperationException("You cannot create nested complex parameters.");
+
             _complexParameterFields.Add(builder);
             return this;
         }
 
         public SlashCommandParameterBuilder AddComplexParameterFields(params SlashCommandParameterBuilder[] fields)
         {
+            if(fields.Any(x => x.IsComplexParameter))
+                throw new InvalidOperationException("You cannot create nested complex parameters.");
+
             _complexParameterFields.AddRange(fields);
             return this;
         }

--- a/src/Discord.Net.Interactions/Builders/Parameters/SlashCommandParameterBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/Parameters/SlashCommandParameterBuilder.cs
@@ -55,6 +55,9 @@ namespace Discord.Interactions.Builders
         /// </summary>
         public bool IsComplexParameter { get; internal set; }
 
+        /// <summary>
+        ///     Gets or sets the initializer delegate for this parameter, if <see cref="IsComplexParameter"/> is <see langword="true"/>.
+        /// </summary>
         public ComplexParameterInitializer ComplexParameterInitializer { get; internal set; }
 
         /// <summary>
@@ -192,6 +195,14 @@ namespace Discord.Interactions.Builders
             return this;
         }
 
+        /// <summary>
+        ///     Adds a parameter builders to <see cref="ComplexParameterFields"/>.
+        /// </summary>
+        /// <param name="configure"><see cref="SlashCommandParameterBuilder"/> factory.</param>
+        /// <returns>
+        ///     The builder instance.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">Thrown if the added field has a <see cref="ComplexParameterAttribute"/>.</exception>
         public SlashCommandParameterBuilder AddComplexParameterField(Action<SlashCommandParameterBuilder> configure)
         {
             SlashCommandParameterBuilder builder = new(Command);
@@ -204,6 +215,14 @@ namespace Discord.Interactions.Builders
             return this;
         }
 
+        /// <summary>
+        ///     Adds parameter builders to <see cref="ComplexParameterFields"/>.
+        /// </summary>
+        /// <param name="fields">New parameter builders to be added to <see cref="ComplexParameterFields"/>.</param>
+        /// <returns>
+        ///     The builder instance.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">Thrown if the added field has a <see cref="ComplexParameterAttribute"/>.</exception>
         public SlashCommandParameterBuilder AddComplexParameterFields(params SlashCommandParameterBuilder[] fields)
         {
             if(fields.Any(x => x.IsComplexParameter))

--- a/src/Discord.Net.Interactions/Builders/Parameters/SlashCommandParameterBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/Parameters/SlashCommandParameterBuilder.cs
@@ -38,6 +38,9 @@ namespace Discord.Interactions.Builders
         /// </summary>
         public IReadOnlyCollection<ChannelType> ChannelTypes => _channelTypes;
 
+        /// <summary>
+        ///     Gets the constructor parameters of this parameter, if <see cref="IsComplexParameter"/> is <see langword="true"/>.
+        /// </summary>
         public IReadOnlyCollection<SlashCommandParameterBuilder> ComplexParameterFields => _complexParameterFields;
 
         /// <summary>

--- a/src/Discord.Net.Interactions/Builders/Parameters/SlashCommandParameterBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/Parameters/SlashCommandParameterBuilder.cs
@@ -54,12 +54,12 @@ namespace Discord.Interactions.Builders
         public TypeConverter TypeConverter { get; private set; }
 
         /// <summary>
-        ///     Gets or sets whether this type should be treated as a complex parameter.
+        ///     Gets whether this type should be treated as a complex parameter.
         /// </summary>
         public bool IsComplexParameter { get; internal set; }
 
         /// <summary>
-        ///     Gets or sets the initializer delegate for this parameter, if <see cref="IsComplexParameter"/> is <see langword="true"/>.
+        ///     Gets the initializer delegate for this parameter, if <see cref="IsComplexParameter"/> is <see langword="true"/>.
         /// </summary>
         public ComplexParameterInitializer ComplexParameterInitializer { get; internal set; }
 
@@ -77,7 +77,8 @@ namespace Discord.Interactions.Builders
         /// <param name="command">Parent command of this parameter.</param>
         /// <param name="name">Name of this command.</param>
         /// <param name="type">Type of this parameter.</param>
-        public SlashCommandParameterBuilder(ICommandBuilder command, string name, Type type, ComplexParameterInitializer complexParameterInitializer = null) : base(command, name, type)
+        public SlashCommandParameterBuilder(ICommandBuilder command, string name, Type type, ComplexParameterInitializer complexParameterInitializer = null)
+            : base(command, name, type)
         {
             ComplexParameterInitializer = complexParameterInitializer;
 

--- a/src/Discord.Net.Interactions/Info/Commands/CommandInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Commands/CommandInfo.cs
@@ -31,6 +31,8 @@ namespace Discord.Interactions
         private readonly ExecuteCallback _action;
         private readonly ILookup<string, PreconditionAttribute> _groupedPreconditions;
 
+        internal IReadOnlyDictionary<string, TParameter> _parameterDictionary { get; }
+
         /// <inheritdoc/>
         public ModuleInfo Module { get; }
 
@@ -78,6 +80,7 @@ namespace Discord.Interactions
 
             _action = builder.Callback;
             _groupedPreconditions = builder.Preconditions.ToLookup(x => x.Group, x => x, StringComparer.Ordinal);
+            _parameterDictionary = Parameters?.ToDictionary(x => x.Name, x => x).ToImmutableDictionary();
         }
 
         /// <inheritdoc/>

--- a/src/Discord.Net.Interactions/Info/Commands/SlashCommandInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Commands/SlashCommandInfo.cs
@@ -30,11 +30,14 @@ namespace Discord.Interactions
         /// <inheritdoc/>
         public override bool SupportsWildCards => false;
 
+        public IReadOnlyCollection<SlashCommandParameterInfo> FlattenedParameters { get; }
+
         internal SlashCommandInfo (Builders.SlashCommandBuilder builder, ModuleInfo module, InteractionService commandService) : base(builder, module, commandService)
         {
             Description = builder.Description;
             DefaultPermission = builder.DefaultPermission;
             Parameters = builder.Parameters.Select(x => x.Build(this)).ToImmutableArray();
+            FlattenedParameters = Parameters.SelectMany(x => x.IsComplexParameter ? x.ComplexParameterFields : new SlashCommandParameterInfo[] { x }).ToImmutableArray();
         }
 
         /// <inheritdoc/>

--- a/src/Discord.Net.Interactions/Info/Commands/SlashCommandInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Commands/SlashCommandInfo.cs
@@ -32,6 +32,9 @@ namespace Discord.Interactions
         /// <inheritdoc/>
         public override bool SupportsWildCards => false;
 
+        /// <summary>
+        ///     Gets the flattened collection of command parameters and complex parameter fields.
+        /// </summary>
         public IReadOnlyCollection<SlashCommandParameterInfo> FlattenedParameters { get; }
 
         internal SlashCommandInfo (Builders.SlashCommandBuilder builder, ModuleInfo module, InteractionService commandService) : base(builder, module, commandService)

--- a/src/Discord.Net.Interactions/Info/Commands/SlashCommandInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Commands/SlashCommandInfo.cs
@@ -13,6 +13,8 @@ namespace Discord.Interactions
     /// </summary>
     public class SlashCommandInfo : CommandInfo<SlashCommandParameterInfo>, IApplicationCommandInfo
     {
+        internal IReadOnlyDictionary<string, SlashCommandParameterInfo> _flattenedParameterDictionary { get; }
+
         /// <summary>
         ///     Gets the command description that will be displayed on Discord.
         /// </summary>
@@ -38,6 +40,8 @@ namespace Discord.Interactions
             DefaultPermission = builder.DefaultPermission;
             Parameters = builder.Parameters.Select(x => x.Build(this)).ToImmutableArray();
             FlattenedParameters = Parameters.SelectMany(x => x.IsComplexParameter ? x.ComplexParameterFields : new SlashCommandParameterInfo[] { x }).ToImmutableArray();
+
+            _flattenedParameterDictionary = FlattenedParameters?.ToDictionary(x => x.Name, x => x).ToImmutableDictionary();
         }
 
         /// <inheritdoc/>

--- a/src/Discord.Net.Interactions/Info/Commands/SlashCommandInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Commands/SlashCommandInfo.cs
@@ -80,8 +80,9 @@ namespace Discord.Interactions
 
                     if(!result.IsSuccess)
                     {
-                        await InvokeModuleEvent(context, result).ConfigureAwait(false);
-                        return result;
+                        var execResult = ExecuteResult.FromError(result);
+                        await InvokeModuleEvent(context, execResult).ConfigureAwait(false);
+                        return execResult;
                     }
 
                     if (result is ParseResult parseResult)

--- a/src/Discord.Net.Interactions/Info/Commands/SlashCommandInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Commands/SlashCommandInfo.cs
@@ -39,7 +39,7 @@ namespace Discord.Interactions
             Description = builder.Description;
             DefaultPermission = builder.DefaultPermission;
             Parameters = builder.Parameters.Select(x => x.Build(this)).ToImmutableArray();
-            FlattenedParameters = Parameters.SelectMany(x => x.IsComplexParameter ? x.ComplexParameterFields : new SlashCommandParameterInfo[] { x }).ToImmutableArray();
+            FlattenedParameters = FlattenParameters(Parameters).ToImmutableArray();
 
             _flattenedParameterDictionary = FlattenedParameters?.ToDictionary(x => x.Name, x => x).ToImmutableDictionary();
         }
@@ -149,6 +149,16 @@ namespace Discord.Interactions
                 return $"Slash Command: \"{base.ToString()}\" for {context.User} in {context.Guild}/{context.Channel}";
             else
                 return $"Slash Command: \"{base.ToString()}\" for {context.User} in {context.Channel}";
+        }
+
+        private static IEnumerable<SlashCommandParameterInfo> FlattenParameters(IEnumerable<SlashCommandParameterInfo> parameters)
+        {
+            foreach (var parameter in parameters)
+                if (!parameter.IsComplexParameter)
+                    yield return parameter;
+                else
+                    foreach(var complexParameterField in parameter.ComplexParameterFields)
+                        yield return complexParameterField;
         }
     }
 }

--- a/src/Discord.Net.Interactions/Info/Commands/SlashCommandInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Commands/SlashCommandInfo.cs
@@ -44,6 +44,10 @@ namespace Discord.Interactions
             Parameters = builder.Parameters.Select(x => x.Build(this)).ToImmutableArray();
             FlattenedParameters = FlattenParameters(Parameters).ToImmutableArray();
 
+            for (var i = 0; i < FlattenedParameters.Count - 1; i++)
+                if (!FlattenedParameters.ElementAt(i).IsRequired && FlattenedParameters.ElementAt(i + 1).IsRequired)
+                    throw new InvalidOperationException("Optional parameters must appear after all required parameters, ComplexParameters with optional parameters must be located at the end.");
+
             _flattenedParameterDictionary = FlattenedParameters?.ToDictionary(x => x.Name, x => x).ToImmutableDictionary();
         }
 

--- a/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
@@ -4,6 +4,13 @@ using System.Linq;
 
 namespace Discord.Interactions
 {
+    /// <summary>
+    ///     Represents a cached argument constructor delegate.
+    /// </summary>
+    /// <param name="args">Method arguments array.</param>
+    /// <returns>
+    ///     Returns the constructed object.
+    /// </returns>
     public delegate object ComplexParameterInitializer(object[] args);
 
     /// <summary>
@@ -67,6 +74,9 @@ namespace Discord.Interactions
         /// </summary>
         public IReadOnlyCollection<ChannelType> ChannelTypes { get; }
 
+        /// <summary>
+        ///     Gets the constructor parameters of this parameter, if <see cref="IsComplexParameter"/> is <see langword="true"/>.
+        /// </summary>
         public IReadOnlyCollection<SlashCommandParameterInfo> ComplexParameterFields { get; }
 
         internal SlashCommandParameterInfo(Builders.SlashCommandParameterBuilder builder, SlashCommandInfo command) : base(builder, command)

--- a/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
@@ -55,7 +55,7 @@ namespace Discord.Interactions
         public bool IsAutocomplete { get; }
 
         /// <summary>
-        ///     Gets or sets whether this type should be treated as a complex parameter.
+        ///     Gets whether this type should be treated as a complex parameter.
         /// </summary>
         public bool IsComplexParameter { get; }
 

--- a/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
@@ -90,7 +90,7 @@ namespace Discord.Interactions
             IsAutocomplete = builder.Autocomplete;
             Choices = builder.Choices.ToImmutableArray();
             ChannelTypes = builder.ChannelTypes.ToImmutableArray();
-            ComplexParameterFields = builder.ComplexParameterFields.Select(x => x.Build(command)).ToImmutableArray();
+            ComplexParameterFields = builder.ComplexParameterFields?.Select(x => x.Build(command)).ToImmutableArray();
 
             _complexParameterInitializer = builder.ComplexParameterInitializer;
         }

--- a/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
@@ -53,11 +53,6 @@ namespace Discord.Interactions
         public bool IsComplexParameter { get; }
 
         /// <summary>
-        ///     Gets or sets whether this type should be treated as a complex parameter.
-        /// </summary>
-        public bool IsComplexParameter { get; }
-
-        /// <summary>
         ///     Gets the Discord option type this parameter represents.
         /// </summary>
         public ApplicationCommandOptionType DiscordOptionType => TypeConverter.GetDiscordType();

--- a/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
@@ -1,13 +1,18 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 
 namespace Discord.Interactions
 {
+    public delegate object ComplexParameterInitializer(object[] args);
+
     /// <summary>
     ///     Represents the parameter info class for <see cref="SlashCommandInfo"/> commands.
     /// </summary>
     public class SlashCommandParameterInfo : CommandParameterInfo
     {
+        internal readonly ComplexParameterInitializer _complexParameterInitializer;
+
         /// <inheritdoc/>
         public new SlashCommandInfo Command => base.Command as SlashCommandInfo;
 
@@ -43,6 +48,11 @@ namespace Discord.Interactions
         public bool IsAutocomplete => AutocompleteHandler is not null;
 
         /// <summary>
+        ///     Gets or sets whether this type should be treated as a complex parameter.
+        /// </summary>
+        public bool IsComplexParameter { get; }
+
+        /// <summary>
         ///     Gets the Discord option type this parameter represents.
         /// </summary>
         public ApplicationCommandOptionType DiscordOptionType => TypeConverter.GetDiscordType();
@@ -57,6 +67,8 @@ namespace Discord.Interactions
         /// </summary>
         public IReadOnlyCollection<ChannelType> ChannelTypes { get; }
 
+        public IReadOnlyCollection<SlashCommandParameterInfo> ComplexParameterFields { get; }
+
         internal SlashCommandParameterInfo(Builders.SlashCommandParameterBuilder builder, SlashCommandInfo command) : base(builder, command)
         {
             TypeConverter = builder.TypeConverter;
@@ -64,8 +76,10 @@ namespace Discord.Interactions
             Description = builder.Description;
             MaxValue = builder.MaxValue;
             MinValue = builder.MinValue;
+            IsComplexParameter = builder.IsComplexParameter;
             Choices = builder.Choices.ToImmutableArray();
             ChannelTypes = builder.ChannelTypes.ToImmutableArray();
+            ComplexParameterFields = builder.ComplexParameterFields.Select(x => x.Build(command)).ToImmutableArray();
         }
     }
 }

--- a/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
@@ -60,9 +60,9 @@ namespace Discord.Interactions
         public bool IsComplexParameter { get; }
 
         /// <summary>
-        ///     Gets the Discord option type this parameter represents.
+        ///     Gets the Discord option type this parameter represents. If the parameter is not a complex parameter.
         /// </summary>
-        public ApplicationCommandOptionType DiscordOptionType => TypeConverter.GetDiscordType();
+        public ApplicationCommandOptionType? DiscordOptionType => TypeConverter?.GetDiscordType();
 
         /// <summary>
         ///     Gets the parameter choices of this Slash Application Command parameter.

--- a/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
@@ -1,13 +1,18 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 
 namespace Discord.Interactions
 {
+    public delegate object ComplexParameterInitializer(object[] args);
+
     /// <summary>
     ///     Represents the parameter info class for <see cref="SlashCommandInfo"/> commands.
     /// </summary>
     public class SlashCommandParameterInfo : CommandParameterInfo
     {
+        internal readonly ComplexParameterInitializer _complexParameterInitializer;
+
         /// <inheritdoc/>
         public new SlashCommandInfo Command => base.Command as SlashCommandInfo;
 
@@ -43,6 +48,11 @@ namespace Discord.Interactions
         public bool IsAutocomplete { get; }
 
         /// <summary>
+        ///     Gets or sets whether this type should be treated as a complex parameter.
+        /// </summary>
+        public bool IsComplexParameter { get; }
+
+        /// <summary>
         ///     Gets the Discord option type this parameter represents.
         /// </summary>
         public ApplicationCommandOptionType DiscordOptionType => TypeConverter.GetDiscordType();
@@ -57,6 +67,8 @@ namespace Discord.Interactions
         /// </summary>
         public IReadOnlyCollection<ChannelType> ChannelTypes { get; }
 
+        public IReadOnlyCollection<SlashCommandParameterInfo> ComplexParameterFields { get; }
+
         internal SlashCommandParameterInfo(Builders.SlashCommandParameterBuilder builder, SlashCommandInfo command) : base(builder, command)
         {
             TypeConverter = builder.TypeConverter;
@@ -64,9 +76,11 @@ namespace Discord.Interactions
             Description = builder.Description;
             MaxValue = builder.MaxValue;
             MinValue = builder.MinValue;
+            IsComplexParameter = builder.IsComplexParameter;
             IsAutocomplete = builder.Autocomplete;
             Choices = builder.Choices.ToImmutableArray();
             ChannelTypes = builder.ChannelTypes.ToImmutableArray();
+            ComplexParameterFields = builder.ComplexParameterFields.Select(x => x.Build(command)).ToImmutableArray();
         }
     }
 }

--- a/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
+++ b/src/Discord.Net.Interactions/Info/Parameters/SlashCommandParameterInfo.cs
@@ -81,6 +81,8 @@ namespace Discord.Interactions
             Choices = builder.Choices.ToImmutableArray();
             ChannelTypes = builder.ChannelTypes.ToImmutableArray();
             ComplexParameterFields = builder.ComplexParameterFields.Select(x => x.Build(command)).ToImmutableArray();
+
+            _complexParameterInitializer = builder.ComplexParameterInitializer;
         }
     }
 }

--- a/src/Discord.Net.Interactions/InteractionService.cs
+++ b/src/Discord.Net.Interactions/InteractionService.cs
@@ -666,9 +666,7 @@ namespace Discord.Interactions
 
                 if(autocompleteHandlerResult.IsSuccess)
                 {
-                    var parameter = autocompleteHandlerResult.Command.FlattenedParameters.FirstOrDefault(x => string.Equals(x.Name, interaction.Data.Current.Name, StringComparison.Ordinal));
-
-                    if(parameter?.AutocompleteHandler is not null)
+                    if (autocompleteHandlerResult.Command._flattenedParameterDictionary.TryGetValue(interaction.Data.Current.Name, out var parameter) && parameter?.AutocompleteHandler is not null)
                         return await parameter.AutocompleteHandler.ExecuteAsync(context, interaction, parameter, services).ConfigureAwait(false);
                 }
             }

--- a/src/Discord.Net.Interactions/InteractionService.cs
+++ b/src/Discord.Net.Interactions/InteractionService.cs
@@ -666,7 +666,7 @@ namespace Discord.Interactions
 
                 if(autocompleteHandlerResult.IsSuccess)
                 {
-                    var parameter = autocompleteHandlerResult.Command.Parameters.FirstOrDefault(x => string.Equals(x.Name, interaction.Data.Current.Name, StringComparison.Ordinal));
+                    var parameter = autocompleteHandlerResult.Command.FlattenedParameters.FirstOrDefault(x => string.Equals(x.Name, interaction.Data.Current.Name, StringComparison.Ordinal));
 
                     if(parameter?.AutocompleteHandler is not null)
                         return await parameter.AutocompleteHandler.ExecuteAsync(context, interaction, parameter, services).ConfigureAwait(false);

--- a/src/Discord.Net.Interactions/Results/ParseResult.cs
+++ b/src/Discord.Net.Interactions/Results/ParseResult.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace Discord.Interactions
+{
+    internal struct ParseResult : IResult
+    {
+        public object Value { get; }
+
+        public InteractionCommandError? Error { get; }
+
+        public string ErrorReason { get; }
+
+        public bool IsSuccess => !Error.HasValue;
+
+        private ParseResult(object value, InteractionCommandError? error, string reason)
+        {
+            Value = value;
+            Error = error;
+            ErrorReason = reason;
+        }
+
+        public static ParseResult FromSuccess(object value) =>
+            new ParseResult(value, null, null);
+
+        public static ParseResult FromError(Exception exception) =>
+            new ParseResult(null, InteractionCommandError.Exception, exception.Message);
+
+        public static ParseResult FromError(InteractionCommandError error, string reason) =>
+            new ParseResult(null, error, reason);
+
+        public static ParseResult FromError(IResult result) =>
+            new ParseResult(null, result.Error, result.ErrorReason);
+
+        public override string ToString() => IsSuccess ? "Success" : $"{Error}: {ErrorReason}";
+    }
+}

--- a/src/Discord.Net.Interactions/Utilities/ApplicationCommandRestUtil.cs
+++ b/src/Discord.Net.Interactions/Utilities/ApplicationCommandRestUtil.cs
@@ -7,28 +7,38 @@ namespace Discord.Interactions
     internal static class ApplicationCommandRestUtil
     {
         #region Parameters
-        public static ApplicationCommandOptionProperties ToApplicationCommandOptionProps(this SlashCommandParameterInfo parameterInfo)
+        public static IEnumerable<ApplicationCommandOptionProperties> ToApplicationCommandOptionProps(this SlashCommandParameterInfo parameterInfo)
         {
-            var props = new ApplicationCommandOptionProperties
+            var result = new List<ApplicationCommandOptionProperties>();
+
+            if(parameterInfo.IsComplexParameter)
+                foreach (var field in parameterInfo.ComplexParameterFields)
+                    result.AddRange(field.ToApplicationCommandOptionProps());
+            else
             {
-                Name = parameterInfo.Name,
-                Description = parameterInfo.Description,
-                Type = parameterInfo.DiscordOptionType,
-                IsRequired = parameterInfo.IsRequired,
-                Choices = parameterInfo.Choices?.Select(x => new ApplicationCommandOptionChoiceProperties
+                var props = new ApplicationCommandOptionProperties
                 {
-                    Name = x.Name,
-                    Value = x.Value
-                })?.ToList(),
-                ChannelTypes = parameterInfo.ChannelTypes?.ToList(),
-                IsAutocomplete = parameterInfo.IsAutocomplete,
-                MaxValue = parameterInfo.MaxValue,
-                MinValue = parameterInfo.MinValue
-            };
+                    Name = parameterInfo.Name,
+                    Description = parameterInfo.Description,
+                    Type = parameterInfo.DiscordOptionType,
+                    IsRequired = parameterInfo.IsRequired,
+                    Choices = parameterInfo.Choices?.Select(x => new ApplicationCommandOptionChoiceProperties
+                    {
+                        Name = x.Name,
+                        Value = x.Value
+                    })?.ToList(),
+                    ChannelTypes = parameterInfo.ChannelTypes?.ToList(),
+                    IsAutocomplete = parameterInfo.IsAutocomplete,
+                    MaxValue = parameterInfo.MaxValue,
+                    MinValue = parameterInfo.MinValue
+                };
 
-            parameterInfo.TypeConverter.Write(props, parameterInfo);
+                parameterInfo.TypeConverter.Write(props, parameterInfo);
 
-            return props;
+                result.Add(props);
+            }
+
+            return result;
         }
         #endregion
 
@@ -58,7 +68,7 @@ namespace Discord.Interactions
                 Description = commandInfo.Description,
                 Type = ApplicationCommandOptionType.SubCommand,
                 IsRequired = false,
-                Options = commandInfo.Parameters?.Select(x => x.ToApplicationCommandOptionProps())?.ToList()
+                Options = commandInfo.Parameters?.SelectMany(x => x.ToApplicationCommandOptionProps())?.ToList()
             };
 
         public static ApplicationCommandProperties ToApplicationCommandProps(this ContextCommandInfo commandInfo)

--- a/src/Discord.Net.Interactions/Utilities/ApplicationCommandRestUtil.cs
+++ b/src/Discord.Net.Interactions/Utilities/ApplicationCommandRestUtil.cs
@@ -56,7 +56,7 @@ namespace Discord.Interactions
             if (commandInfo.Parameters.Count > SlashCommandBuilder.MaxOptionsCount)
                 throw new InvalidOperationException($"Slash Commands cannot have more than {SlashCommandBuilder.MaxOptionsCount} command parameters");
 
-            props.Options = commandInfo.Parameters.Select(x => x.ToApplicationCommandOptionProps())?.ToList() ?? Optional<List<ApplicationCommandOptionProperties>>.Unspecified;
+            props.Options = commandInfo.Parameters.SelectMany(x => x.ToApplicationCommandOptionProps())?.ToList() ?? Optional<List<ApplicationCommandOptionProperties>>.Unspecified;
 
             return props;
         }

--- a/src/Discord.Net.Interactions/Utilities/ApplicationCommandRestUtil.cs
+++ b/src/Discord.Net.Interactions/Utilities/ApplicationCommandRestUtil.cs
@@ -7,28 +7,38 @@ namespace Discord.Interactions
     internal static class ApplicationCommandRestUtil
     {
         #region Parameters
-        public static ApplicationCommandOptionProperties ToApplicationCommandOptionProps(this SlashCommandParameterInfo parameterInfo)
+        public static IEnumerable<ApplicationCommandOptionProperties> ToApplicationCommandOptionProps(this SlashCommandParameterInfo parameterInfo)
         {
-            var props = new ApplicationCommandOptionProperties
+            var result = new List<ApplicationCommandOptionProperties>();
+
+            if(parameterInfo.IsComplexParameter)
+                foreach (var field in parameterInfo.ComplexParameterFields)
+                    result.AddRange(field.ToApplicationCommandOptionProps());
+            else
             {
-                Name = parameterInfo.Name,
-                Description = parameterInfo.Description,
-                Type = parameterInfo.DiscordOptionType,
-                IsRequired = parameterInfo.IsRequired,
-                Choices = parameterInfo.Choices?.Select(x => new ApplicationCommandOptionChoiceProperties
+                var props = new ApplicationCommandOptionProperties
                 {
-                    Name = x.Name,
-                    Value = x.Value
-                })?.ToList(),
-                ChannelTypes = parameterInfo.ChannelTypes?.ToList(),
-                IsAutocomplete = parameterInfo.IsAutocomplete,
-                MaxValue = parameterInfo.MaxValue,
-                MinValue = parameterInfo.MinValue
-            };
+                    Name = parameterInfo.Name,
+                    Description = parameterInfo.Description,
+                    Type = parameterInfo.DiscordOptionType,
+                    IsRequired = parameterInfo.IsRequired,
+                    Choices = parameterInfo.Choices?.Select(x => new ApplicationCommandOptionChoiceProperties
+                    {
+                        Name = x.Name,
+                        Value = x.Value
+                    })?.ToList(),
+                    ChannelTypes = parameterInfo.ChannelTypes?.ToList(),
+                    IsAutocomplete = parameterInfo.IsAutocomplete,
+                    MaxValue = parameterInfo.MaxValue,
+                    MinValue = parameterInfo.MinValue
+                };
 
-            parameterInfo.TypeConverter.Write(props, parameterInfo);
+                parameterInfo.TypeConverter.Write(props, parameterInfo);
 
-            return props;
+                result.Add(props);
+            }
+
+            return result;
         }
         #endregion
 
@@ -40,7 +50,7 @@ namespace Discord.Interactions
                 Name = commandInfo.Name,
                 Description = commandInfo.Description,
                 IsDefaultPermission = commandInfo.DefaultPermission,
-                Options = commandInfo.Parameters.Select(x => x.ToApplicationCommandOptionProps())?.ToList() ?? Optional<List<ApplicationCommandOptionProperties>>.Unspecified
+                Options = commandInfo.Parameters.SelectMany(x => x.ToApplicationCommandOptionProps())?.ToList() ?? Optional<List<ApplicationCommandOptionProperties>>.Unspecified
             };
 
         public static ApplicationCommandOptionProperties ToApplicationCommandOptionProps(this SlashCommandInfo commandInfo) =>
@@ -50,7 +60,7 @@ namespace Discord.Interactions
                 Description = commandInfo.Description,
                 Type = ApplicationCommandOptionType.SubCommand,
                 IsRequired = false,
-                Options = commandInfo.Parameters?.Select(x => x.ToApplicationCommandOptionProps())?.ToList()
+                Options = commandInfo.Parameters?.SelectMany(x => x.ToApplicationCommandOptionProps())?.ToList()
             };
 
         public static ApplicationCommandProperties ToApplicationCommandProps(this ContextCommandInfo commandInfo) =>

--- a/src/Discord.Net.Interactions/Utilities/ApplicationCommandRestUtil.cs
+++ b/src/Discord.Net.Interactions/Utilities/ApplicationCommandRestUtil.cs
@@ -13,7 +13,7 @@ namespace Discord.Interactions
             {
                 Name = parameterInfo.Name,
                 Description = parameterInfo.Description,
-                Type = parameterInfo.DiscordOptionType,
+                Type = parameterInfo.DiscordOptionType.Value,
                 IsRequired = parameterInfo.IsRequired,
                 Choices = parameterInfo.Choices?.Select(x => new ApplicationCommandOptionChoiceProperties
                 {

--- a/src/Discord.Net.Interactions/Utilities/ReflectionUtils.cs
+++ b/src/Discord.Net.Interactions/Utilities/ReflectionUtils.cs
@@ -44,7 +44,7 @@ namespace Discord.Interactions
                 throw new Exception($"Failed to create \"{ownerType.FullName}\".", ex);
             }
         }
-        internal static ConstructorInfo GetConstructor (TypeInfo ownerType)
+        private static ConstructorInfo GetConstructor (TypeInfo ownerType)
         {
             var constructors = ownerType.DeclaredConstructors.Where(x => !x.IsStatic).ToArray();
             if (constructors.Length == 0)


### PR DESCRIPTION
This PR adds a new feature called complex parameters to the Interaction Service. This allows users to create slash command options using an objects constructor. Also allowing complex objects to be created which cannot be infered from only one input value.
Constructor methods support every attribute type that can be used with the regular slash commands ([Autocomplete], [Summary] etc. ).
Preferred constructor of a Type can be specified either by passing a `Type[]` to the `ComplexParameterAttribute` or tagging a type constructor with the `ComplexParameterCtorAttribute`. If nothing is specified, the InteractionService defaults to the only public constructor of the type.
TypeConverter pattern is used to parse the constructor methods objects.

>This PR is ready to be merged but it changes the way SlashCommandParameters are parsed on execution, so i dont think this change should be included in the D-Net v3 roll out.

![image](https://user-images.githubusercontent.com/57065323/145730610-79efb99c-0306-4525-837b-7a9101c07f16.png)
![image](https://user-images.githubusercontent.com/57065323/145730650-f05d967b-baa2-443c-99a6-f7b9bcc08745.png)
![image](https://user-images.githubusercontent.com/57065323/145730660-507a339d-f09f-4849-8880-483e1ad9c5a9.png)
