### PR TITLE
Fixed applications not containing the TOS and Privacy strings.

### DIFF
--- a/src/Discord.Net.Core/Entities/IApplication.cs
+++ b/src/Discord.Net.Core/Entities/IApplication.cs
@@ -19,7 +19,9 @@ namespace Discord
         ///     Gets the RPC origins of the application.
         /// </summary>
         IReadOnlyCollection<string> RPCOrigins { get; }
-
+        /// <summary>
+        ///     Gets the application's public flags.
+        /// </summary>
         ApplicationFlags Flags { get; }
         /// <summary>
         ///     Gets a collection of install parameters for this application.

--- a/src/Discord.Net.Core/Entities/IApplication.cs
+++ b/src/Discord.Net.Core/Entities/IApplication.cs
@@ -19,6 +19,7 @@ namespace Discord
         ///     Gets the RPC origins of the application.
         /// </summary>
         IReadOnlyCollection<string> RPCOrigins { get; }
+
         ApplicationFlags Flags { get; }
         /// <summary>
         ///     Gets a collection of install parameters for this application.
@@ -44,10 +45,18 @@ namespace Discord
         ///     Gets the team associated with this application if there is one.
         /// </summary>
         ITeam Team { get; }
-
         /// <summary>
         ///     Gets the partial user object containing info on the owner of the application.
         /// </summary>
         IUser Owner { get; }
+        /// <summary>
+        ///     Gets the url of the app's terms of service.
+        /// </summary>
+        public string TermsOfService { get; }
+        /// <summary>
+        ///     Gets the the url of the app's privacy policy.
+        /// </summary>
+        public string PrivacyPolicy { get; }
+
     }
 }

--- a/src/Discord.Net.Rest/API/Common/Application.cs
+++ b/src/Discord.Net.Rest/API/Common/Application.cs
@@ -20,16 +20,14 @@ namespace Discord.API
         public bool BotRequiresCodeGrant { get; set; }
         [JsonProperty("install_params")]
         public Optional<InstallParams> InstallParams { get; set; }
-
         [JsonProperty("team")]
         public Team Team { get; set; }
-
         [JsonProperty("flags"), Int53]
         public Optional<ApplicationFlags> Flags { get; set; }
         [JsonProperty("owner")]
         public Optional<User> Owner { get; set; }
+        [JsonProperty("tags")]
         public Optional<string[]> Tags { get; set; }
-
         [JsonProperty("terms_of_service_url")]
         public string TermsOfService { get; set; }
         [JsonProperty("privacy_policy_url")]

--- a/src/Discord.Net.Rest/API/Common/Application.cs
+++ b/src/Discord.Net.Rest/API/Common/Application.cs
@@ -29,5 +29,10 @@ namespace Discord.API
         [JsonProperty("owner")]
         public Optional<User> Owner { get; set; }
         public Optional<string[]> Tags { get; set; }
+
+        [JsonProperty("terms_of_service_url")]
+        public string TermsOfService { get; set; }
+        [JsonProperty("privacy_policy_url")]
+        public string PrivacyPolicy { get; set; }
     }
 }

--- a/src/Discord.Net.Rest/Entities/RestApplication.cs
+++ b/src/Discord.Net.Rest/Entities/RestApplication.cs
@@ -29,10 +29,12 @@ namespace Discord.Rest
         public bool BotRequiresCodeGrant { get; private set; }
         /// <inheritdoc />
         public ITeam Team { get; private set; }
-
         /// <inheritdoc />
         public IUser Owner { get; private set; }
-
+        /// <inheritdoc />
+        public string TermsOfService { get; private set; }
+        /// <inheritdoc />
+        public string PrivacyPolicy { get; private set; }
         /// <inheritdoc />
         public DateTimeOffset CreatedAt => SnowflakeUtils.FromSnowflake(Id);
         /// <inheritdoc />
@@ -61,6 +63,8 @@ namespace Discord.Rest
             IsBotPublic = model.IsBotPublic;
             BotRequiresCodeGrant = model.BotRequiresCodeGrant;
             Tags = model.Tags.GetValueOrDefault(null)?.ToImmutableArray() ?? ImmutableArray<string>.Empty;
+            PrivacyPolicy = model.PrivacyPolicy;
+            TermsOfService = model.TermsOfService;
             var installParams = model.InstallParams.GetValueOrDefault(null);
             InstallParams = new ApplicationInstallParams(installParams?.Scopes ?? new string[0], (GuildPermission?)installParams?.Permission ?? null);
 


### PR DESCRIPTION
## Fixed Application Modal
This is a PR fixing the application modal. It adds two fields, the TOS and Privacy Policy, fields that are in Discord's API but not DNet's.

#### Related issue: https://github.com/discord-net/Discord.Net/issues/1968