### PR TITLE
Add callback to rest context

### DIFF
--- a/src/Discord.Net.Core/Interactions/IRestInteractionContext.cs
+++ b/src/Discord.Net.Core/Interactions/IRestInteractionContext.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Discord
+{
+    public interface IRestInteractionContext : IInteractionContext
+    {
+        /// <summary>
+        ///     Gets or sets the callback to use when the service has outgoing json for the rest webhook.
+        /// </summary>
+        /// <remarks>
+        ///     If this property is <see langword="null"/> the default callback will be used.
+        /// </remarks>
+        Func<string, Task> InteractionResponseCallback { get; }
+    }
+}

--- a/src/Discord.Net.Interactions/AutocompleteHandlers/AutocompleteHandler.cs
+++ b/src/Discord.Net.Interactions/AutocompleteHandlers/AutocompleteHandler.cs
@@ -60,7 +60,11 @@ namespace Discord.Interactions
                     {
                         case RestAutocompleteInteraction restAutocomplete:
                             var payload = restAutocomplete.Respond(result.Suggestions);
-                            await InteractionService._restResponseCallback(context, payload).ConfigureAwait(false);
+
+                            if (context is IRestInteractionContext restContext && restContext.InteractionResponseCallback != null)
+                                await restContext.InteractionResponseCallback.Invoke(payload).ConfigureAwait(false);
+                            else
+                                await InteractionService._restResponseCallback(context, payload).ConfigureAwait(false);
                             break;
                         case SocketAutocompleteInteraction socketAutocomplete:
                             await socketAutocomplete.RespondAsync(result.Suggestions).ConfigureAwait(false);

--- a/src/Discord.Net.Interactions/RestInteractionModuleBase.cs
+++ b/src/Discord.Net.Interactions/RestInteractionModuleBase.cs
@@ -30,7 +30,12 @@ namespace Discord.Interactions
             if (Context.Interaction is not RestInteraction restInteraction)
                 throw new InvalidOperationException($"Invalid interaction type. Interaction must be a type of {nameof(RestInteraction)} in order to execute this method");
 
-            await InteractionService._restResponseCallback(Context, restInteraction.Defer(ephemeral, options)).ConfigureAwait(false);
+            var payload = restInteraction.Defer(ephemeral, options);
+
+            if (Context is IRestInteractionContext restContext && restContext.InteractionResponseCallback != null)
+                await restContext.InteractionResponseCallback.Invoke(payload).ConfigureAwait(false);
+            else
+                await InteractionService._restResponseCallback(Context, payload).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -53,7 +58,12 @@ namespace Discord.Interactions
             if (Context.Interaction is not RestInteraction restInteraction)
                 throw new InvalidOperationException($"Invalid interaction type. Interaction must be a type of {nameof(RestInteraction)} in order to execute this method");
 
-            await InteractionService._restResponseCallback(Context, restInteraction.Respond(text, embeds, isTTS, ephemeral, allowedMentions, components, embed, options)).ConfigureAwait(false);
+            var payload = restInteraction.Respond(text, embeds, isTTS, ephemeral, allowedMentions, components, embed, options);
+
+            if (Context is IRestInteractionContext restContext && restContext.InteractionResponseCallback != null)
+                await restContext.InteractionResponseCallback.Invoke(payload).ConfigureAwait(false);
+            else
+                await InteractionService._restResponseCallback(Context, payload).ConfigureAwait(false);
         }
     }
 }

--- a/src/Discord.Net.Rest/Interactions/RestInteractionContext.cs
+++ b/src/Discord.Net.Rest/Interactions/RestInteractionContext.cs
@@ -1,9 +1,12 @@
+using System;
+using System.Threading.Tasks;
+
 namespace Discord.Rest
 {
     /// <summary>
     ///     Represents a Rest based context of an <see cref="IDiscordInteraction"/>.
     /// </summary>
-    public class RestInteractionContext<TInteraction> : IInteractionContext
+    public class RestInteractionContext<TInteraction> : IRestInteractionContext
         where TInteraction : RestInteraction
     {
         /// <summary>
@@ -35,6 +38,14 @@ namespace Discord.Rest
         public TInteraction Interaction { get; }
 
         /// <summary>
+        ///     Gets or sets the callback to use when the service has outgoing json for the rest webhook.
+        /// </summary>
+        /// <remarks>
+        ///     If this property is <see langword="null"/> the default callback will be used.
+        /// </remarks>
+        public Func<string, Task> InteractionResponseCallback { get; set; }
+
+        /// <summary>
         ///     Initializes a new <see cref="RestInteractionContext{TInteraction}"/>. 
         /// </summary>
         /// <param name="client">The underlying client.</param>
@@ -46,6 +57,18 @@ namespace Discord.Rest
             Channel = interaction.Channel;
             User = interaction.User;
             Interaction = interaction;
+        }
+
+        /// <summary>
+        ///     Initializes a new <see cref="RestInteractionContext{TInteraction}"/>. 
+        /// </summary>
+        /// <param name="client">The underlying client.</param>
+        /// <param name="interaction">The underlying interaction.</param>
+        /// <param name="interactionResponseCallback">The callback for outgoing json.</param>
+        public RestInteractionContext(DiscordRestClient client, TInteraction interaction, Func<string, Task> interactionResponseCallback)
+            : this(client, interaction)
+        {
+            InteractionResponseCallback = InteractionResponseCallback;
         }
 
         // IInterationContext
@@ -76,5 +99,14 @@ namespace Discord.Rest
         /// <param name="client">The underlying client</param>
         /// <param name="interaction">The underlying interaction</param>
         public RestInteractionContext(DiscordRestClient client, RestInteraction interaction) : base(client, interaction) { }
+
+        /// <summary>
+        ///     Initializes a new <see cref="RestInteractionContext"/> 
+        /// </summary>
+        /// <param name="client">The underlying client</param>
+        /// <param name="interaction">The underlying interaction</param>
+        /// <param name="interactionResponseCallback">The callback for outgoing json.</param>
+        public RestInteractionContext(DiscordRestClient client, RestInteraction interaction, Func<string, Task> interactionResponseCallback)
+            : base(client, interaction, interactionResponseCallback) { }
     }
 }


### PR DESCRIPTION
## Summary
This PR adds the `InteractionResponseCallback` property to `RestInteractionContext` and introduces the interface `IRestInteractionContext`. This allows the process of writing the respond function much simpler, ex:
```cs

async Task WriteCallback(string payload)
{
    await response.OutputStream.WriteAsync(payload);
}

var context = new RestInteractionContext(client, interaction, WriteCallback);
await interactionService.ExecuteCommandAsync(context, services);
response.StatusCode = 200;
response.Close();
```

If no callback is passed into the ctor of `RestInteractionContext` then the default global callback is used, the callbacks are mutually exclusive.