### PR TITLE
Add before and after execute async to interaction modules

### DIFF
--- a/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
+++ b/src/Discord.Net.Interactions/Builders/ModuleClassBuilder.cs
@@ -311,6 +311,7 @@ namespace Discord.Interactions.Builders
 
                 try
                 {
+                    await instance.BeforeExecuteAsync(commandInfo).ConfigureAwait(false);
                     instance.BeforeExecute(commandInfo);
                     var task = commandInvoker(instance, args) ?? Task.Delay(0);
 
@@ -332,6 +333,7 @@ namespace Discord.Interactions.Builders
                 }
                 finally
                 {
+                    await instance.AfterExecuteAsync(commandInfo).ConfigureAwait(false);
                     instance.AfterExecute(commandInfo);
                     ( instance as IDisposable )?.Dispose();
                 }

--- a/src/Discord.Net.Interactions/IInteractionModuleBase.cs
+++ b/src/Discord.Net.Interactions/IInteractionModuleBase.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace Discord.Interactions
 {
     /// <summary>
@@ -12,10 +14,21 @@ namespace Discord.Interactions
         void SetContext (IInteractionContext context);
 
         /// <summary>
+        ///     Method body to be executed asynchronously before executing an application command.
+        /// </summary>
+        /// <param name="command">Command information related to the Discord Application Command.</param>
+        Task BeforeExecuteAsync(ICommandInfo command);
+        /// <summary>
         ///     Method body to be executed before executing an application command.
         /// </summary>
         /// <param name="command">Command information related to the Discord Application Command.</param>
         void BeforeExecute (ICommandInfo command);
+
+        /// <summary>
+        ///     Method body to be executed asynchronously after an application command execution.
+        /// </summary>
+        /// <param name="command">Command information related to the Discord Application Command.</param>
+        Task AfterExecuteAsync(ICommandInfo command);
 
         /// <summary>
         ///     Method body to be executed after an application command execution.

--- a/src/Discord.Net.Interactions/InteractionModuleBase.cs
+++ b/src/Discord.Net.Interactions/InteractionModuleBase.cs
@@ -21,6 +21,12 @@ namespace Discord.Interactions
         public virtual void BeforeExecute (ICommandInfo command) { }
 
         /// <inheritdoc/>
+        public virtual Task BeforeExecuteAsync(ICommandInfo command) => Task.CompletedTask;
+
+        /// <inheritdoc/>
+        public virtual Task AfterExecuteAsync(ICommandInfo command) => Task.CompletedTask;
+
+        /// <inheritdoc/>
         public virtual void OnModuleBuilding (InteractionService commandService, ModuleInfo module) { }
 
         internal void SetContext (IInteractionContext context)


### PR DESCRIPTION
## Summary
This PR adds `BeforeExecuteAsync` and `AfterExecuteAsync` methods to the `IInteractionModuleBase` interface allowing people to use async code in before/after execute.

The async methods are called before the non async versions.