### PR TITLE
Add MaxUploadLimit to guilds

### DIFF
--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -354,7 +354,7 @@ namespace Discord
         /// </returns>
         bool IsBoostProgressBarEnabled { get; }
         /// <summary>
-        ///     Gets the upload limit in bytes for this guild. This number is dependand on the guilds boost status.
+        ///     Gets the upload limit in bytes for this guild. This number is dependant on the guild's boost status.
         /// </summary>
         ulong MaxUploadLimit { get; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -354,7 +354,7 @@ namespace Discord
         /// </returns>
         bool IsBoostProgressBarEnabled { get; }
         /// <summary>
-        ///     Gets the upload limit in bytes for this guild. This number is dependant on the guild's boost status.
+        ///     Gets the upload limit in bytes for this guild. This number is dependent on the guild's boost status.
         /// </summary>
         ulong MaxUploadLimit { get; }
         /// <summary>

--- a/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
+++ b/src/Discord.Net.Core/Entities/Guilds/IGuild.cs
@@ -353,7 +353,10 @@ namespace Discord
         ///     <see langword="true"/> if the boost progress bar is enabled; otherwise <see langword="false"/>.
         /// </returns>
         bool IsBoostProgressBarEnabled { get; }
-
+        /// <summary>
+        ///     Gets the upload limit in bytes for this guild. This number is dependand on the guilds boost status.
+        /// </summary>
+        ulong MaxUploadLimit { get; }
         /// <summary>
         ///     Modifies this guild.
         /// </summary>

--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -372,6 +372,16 @@ namespace Discord.Rest
                 Preconditions.NotNullOrEmpty(attachment.FileName, nameof(attachment.FileName), "File Name must not be empty or null");
             }
 
+            if(channel is ITextChannel guildTextChannel)
+            {
+                var contentSize = (ulong)attachments.Sum(x => x.Stream.Length);
+
+                if(contentSize > guildTextChannel.Guild.MaxUploadLimit)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(attachments), $"Collective file size exceeds the max file size of {guildTextChannel.Guild.MaxUploadLimit} bytes in that guild!");
+                }
+            }
+
             // check that user flag and user Id list are exclusive, same with role flag and role Id list
             if (allowedMentions != null && allowedMentions.AllowedTypes.HasValue)
             {

--- a/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/GuildHelper.cs
@@ -124,6 +124,15 @@ namespace Discord.Rest
         {
             await client.ApiClient.DeleteGuildAsync(guild.Id, options).ConfigureAwait(false);
         }
+        public static ulong GetUploadLimit(IGuild guild)
+        {
+            return guild.PremiumTier switch
+            {
+                PremiumTier.Tier2 => 50ul * 1000000,
+                PremiumTier.Tier3 => 100ul * 1000000,
+                _ => 8ul * 1000000
+            };
+        }
         #endregion
 
         #region Bans

--- a/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
+++ b/src/Discord.Net.Rest/Entities/Guilds/RestGuild.cs
@@ -99,6 +99,9 @@ namespace Discord.Rest
                 };
             }
         }
+        /// <inheritdoc/>
+        public ulong MaxUploadLimit
+            => GuildHelper.GetUploadLimit(this);
         /// <inheritdoc />
         public NsfwLevel NsfwLevel { get; private set; }
         /// <inheritdoc />

--- a/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
+++ b/src/Discord.Net.WebSocket/Entities/Guilds/SocketGuild.cs
@@ -199,6 +199,9 @@ namespace Discord.WebSocket
                 };
             }
         }
+        /// <inheritdoc/>
+        public ulong MaxUploadLimit
+            => GuildHelper.GetUploadLimit(this);
         /// <summary>
         ///     Gets the widget channel (i.e. the channel set in the guild's widget settings) in this guild.
         /// </summary>


### PR DESCRIPTION
## Summary
This PR adds `MaxUploadLimit` to IGuild defining the max upload limit in bytes for that guild. This is used when sending files to guild channels to check whether or not the filesize limit is exceeded.