### PR TITLE
Display name support for enum type converter

### DIFF
--- a/docs/guides/int_framework/samples/intro/groupattribute.cs
+++ b/docs/guides/int_framework/samples/intro/groupattribute.cs
@@ -10,8 +10,8 @@ public enum Animal
 {
     Cat,
     Dog,
-    // You can also use the DisplayAttribute to change how they appear in the choice menu.
-    [Display(Name = "Guinea pig")]
+    // You can also use the ChoiceDisplay attribute to change how they appear in the choice menu.
+    [ChoiceDisplay("Guinea pig")]
     GuineaPig
 }
 

--- a/docs/guides/int_framework/samples/intro/groupattribute.cs
+++ b/docs/guides/int_framework/samples/intro/groupattribute.cs
@@ -1,16 +1,18 @@
 [SlashCommand("blep", "Send a random adorable animal photo")]
-public async Task Blep([Choice("Dog", "dog"), Choice("Cat", "cat"), Choice("Penguin", "penguin")] string animal)
+public async Task Blep([Choice("Dog", "dog"), Choice("Cat", "cat"), Choice("Guinea pig", "GuineaPig")] string animal)
 {
     ...
 }
 
-// In most cases, you can use an enum to replace the seperate choice attributes in a command.
+// In most cases, you can use an enum to replace the separate choice attributes in a command.
 
 public enum Animal
 {
     Cat,
     Dog,
-    Penguin
+    // You can also use the DisplayAttribute to change how they appear in the choice menu.
+    [Display(Name = "Guinea pig")]
+    GuineaPig
 }
 
 [SlashCommand("blep", "Send a random adorable animal photo")]

--- a/samples/04_interactions_framework/ExampleEnum.cs
+++ b/samples/04_interactions_framework/ExampleEnum.cs
@@ -1,3 +1,4 @@
+using Discord.Interactions;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -13,7 +14,7 @@ namespace _04_interactions_framework
         Second,
         Third,
         Fourth,
-        [Display(Name = "Twenty First")]
+        [ChoiceDisplay("Twenty First")]
         TwentyFirst
     }
 }

--- a/samples/04_interactions_framework/ExampleEnum.cs
+++ b/samples/04_interactions_framework/ExampleEnum.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -11,6 +12,8 @@ namespace _04_interactions_framework
         First,
         Second,
         Third,
-        Fourth
+        Fourth,
+        [Display(Name = "Twenty First")]
+        TwentyFirst
     }
 }

--- a/src/Discord.Net.Interactions/Attributes/EnumChoiceAttribute.cs
+++ b/src/Discord.Net.Interactions/Attributes/EnumChoiceAttribute.cs
@@ -3,7 +3,7 @@ using System;
 namespace Discord.Interactions
 {
     /// <summary>
-    ///     Customize the displayed value of a slash command choice enum.
+    ///     Customize the displayed value of a slash command choice enum. Only works with the default enum type converter.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
     public class ChoiceDisplayAttribute : Attribute

--- a/src/Discord.Net.Interactions/Attributes/EnumChoiceAttribute.cs
+++ b/src/Discord.Net.Interactions/Attributes/EnumChoiceAttribute.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Discord.Interactions
+{
+    /// <summary>
+    ///     Customize the displayed value of a slash command choice enum.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
+    public class ChoiceDisplayAttribute : Attribute
+    {
+        /// <summary>
+        ///     Gets the name of the parameter.
+        /// </summary>
+        public string Name { get; } = null;
+
+        /// <summary>
+        ///     Modify the default name and description values of a Slash Command parameter.
+        /// </summary>
+        /// <param name="name">Name of the parameter.</param>
+        public ChoiceDisplayAttribute(string name)
+        {
+            Name = name;
+        }
+    }
+}

--- a/src/Discord.Net.Interactions/Discord.Net.Interactions.csproj
+++ b/src/Discord.Net.Interactions/Discord.Net.Interactions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../Discord.Net.targets" />
   <Import Project="../../StyleAnalyzer.targets" />
   <PropertyGroup>
@@ -19,9 +19,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"  Condition="'$(TargetFramework)' == 'net461'"/>
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"  Condition="'$(TargetFramework)' == 'netstandard2.0'"/>
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"  Condition="'$(TargetFramework)' == 'netstandard2.1'"/>
     <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/Discord.Net.Interactions/Discord.Net.Interactions.csproj
+++ b/src/Discord.Net.Interactions/Discord.Net.Interactions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../../Discord.Net.targets" />
   <Import Project="../../StyleAnalyzer.targets" />
   <PropertyGroup>
@@ -19,6 +19,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"  Condition="'$(TargetFramework)' == 'net461'"/>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"  Condition="'$(TargetFramework)' == 'netstandard2.0'"/>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"  Condition="'$(TargetFramework)' == 'netstandard2.1'"/>
     <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
 

--- a/src/Discord.Net.Interactions/TypeConverters/EnumConverter.cs
+++ b/src/Discord.Net.Interactions/TypeConverters/EnumConverter.cs
@@ -2,6 +2,7 @@ using Discord.WebSocket;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Discord.Interactions
@@ -27,12 +28,14 @@ namespace Discord.Interactions
                 var choices = new List<ApplicationCommandOptionChoiceProperties>();
 
                 foreach (var member in members)
+                {
+                    var displayValue = member.GetCustomAttribute<ChoiceDisplayAttribute>()?.Name ?? member.Name;
                     choices.Add(new ApplicationCommandOptionChoiceProperties
                     {
-                        Name = member.Name,
+                        Name = displayValue,
                         Value = member.Name
                     });
-
+                }
                 properties.Choices = choices;
             }
         }

--- a/src/Discord.Net.Interactions/TypeConverters/EnumConverter.cs
+++ b/src/Discord.Net.Interactions/TypeConverters/EnumConverter.cs
@@ -1,7 +1,9 @@
 using Discord.WebSocket;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Discord.Interactions
@@ -27,12 +29,15 @@ namespace Discord.Interactions
                 var choices = new List<ApplicationCommandOptionChoiceProperties>();
 
                 foreach (var member in members)
+                {
+                    var displayValue = member.GetCustomAttribute<DisplayAttribute>()?.Name ?? member.Name;
+
                     choices.Add(new ApplicationCommandOptionChoiceProperties
                     {
-                        Name = member.Name,
+                        Name = displayValue,
                         Value = member.Name
                     });
-
+                }
                 properties.Choices = choices;
             }
         }

--- a/src/Discord.Net.Interactions/TypeConverters/EnumConverter.cs
+++ b/src/Discord.Net.Interactions/TypeConverters/EnumConverter.cs
@@ -1,9 +1,7 @@
 using Discord.WebSocket;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Discord.Interactions
@@ -29,15 +27,12 @@ namespace Discord.Interactions
                 var choices = new List<ApplicationCommandOptionChoiceProperties>();
 
                 foreach (var member in members)
-                {
-                    var displayValue = member.GetCustomAttribute<DisplayAttribute>()?.Name ?? member.Name;
-
                     choices.Add(new ApplicationCommandOptionChoiceProperties
                     {
-                        Name = displayValue,
+                        Name = member.Name,
                         Value = member.Name
                     });
-                }
+
                 properties.Choices = choices;
             }
         }


### PR DESCRIPTION
This PR adds basic support for enum's that have been decorated with the `DisplayAttribute` from `System.ComponentModel.DataAnnotations`.

I went with DisplayAttribute over other options because a lot of peoples enums might already be using this attribute from things like MVC, and it has support for localization. However doing so requires changing the project references to include the annotations library for the net461, and netstandard tagets (support is included in the core.app package for net5+). So if it would be better to use a custom attribute to avoid adding this package please let me know and I can modify the pull request.