### PR TITLE
Add method UpdateAsync to IComponentInteraction

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/IComponentInteraction.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/IComponentInteraction.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Threading.Tasks;
+
 namespace Discord
 {
     /// <summary>
@@ -14,5 +17,13 @@ namespace Discord
         ///     Gets the message that contained the trigger for this interaction.
         /// </summary>
         IUserMessage Message { get; }
+
+        /// <summary>
+        ///     Updates the message which this component resides in with the type <see cref="InteractionResponseType.UpdateMessage"/>
+        /// </summary>
+        /// <param name="func">A delegate containing the properties to modify the message with.</param>
+        /// <param name="options">The request options for this <see langword="async"/> request.</param>
+        /// <returns>A task that represents the asynchronous operation of updating the message.</returns>
+        Task UpdateAsync(Action<MessageProperties> func, RequestOptions options = null);
     }
 }

--- a/src/Discord.Net.Rest/Entities/Interactions/MessageComponents/RestMessageComponent.cs
+++ b/src/Discord.Net.Rest/Entities/Interactions/MessageComponents/RestMessageComponent.cs
@@ -452,5 +452,9 @@ namespace Discord.Rest
 
         /// <inheritdoc/>
         IUserMessage IComponentInteraction.Message => Message;
+
+        /// <inheritdoc />
+        Task IComponentInteraction.UpdateAsync(Action<MessageProperties> func, RequestOptions options)
+            => Task.FromResult(Update(func, options));
     }
 }

--- a/src/Discord.Net.WebSocket/Entities/Interaction/MessageComponents/SocketMessageComponent.cs
+++ b/src/Discord.Net.WebSocket/Entities/Interaction/MessageComponents/SocketMessageComponent.cs
@@ -202,12 +202,7 @@ namespace Discord.WebSocket
             HasResponded = true;
         }
 
-        /// <summary>
-        ///     Updates the message which this component resides in with the type <see cref="InteractionResponseType.UpdateMessage"/>
-        /// </summary>
-        /// <param name="func">A delegate containing the properties to modify the message with.</param>
-        /// <param name="options">The request options for this <see langword="async"/> request.</param>
-        /// <returns>A task that represents the asynchronous operation of updating the message.</returns>
+        /// <inheritdoc/>
         public async Task UpdateAsync(Action<MessageProperties> func, RequestOptions options = null)
         {
             var args = new MessageProperties();


### PR DESCRIPTION
This PR adds the method `UpdateAsync` to `IComponentInteraction`.
This should be added because component interactions share a way update a message with response/callback type 7 (via `UpdateAsync`)