### PR TITLE
Fix small mistake in bulk for slash commands

### DIFF
--- a/docs/guides/int_basics/application-commands/slash-commands/bulk-overwrite-of-global-slash-commands.md
+++ b/docs/guides/int_basics/application-commands/slash-commands/bulk-overwrite-of-global-slash-commands.md
@@ -27,6 +27,7 @@ public async Task Client_Ready()
         SlashCommandBuilder globalCommandAddFamily = new SlashCommandBuilder();
         globalCommandAddFamily.WithName("add-family");
         globalCommandAddFamily.WithDescription("Add a family");
+        globalCommandAddFamily.AddOptions(slashCommandOptionBuilder);
         applicationCommandProperties.Add(globalCommandAddFamily.Build());
 
         await _client.BulkOverwriteGlobalApplicationCommandsAsync(applicationCommandProperties.ToArray());


### PR DESCRIPTION
add the slashCommandOptionBuilder to the actual globalCommandAddFamily command in the documentation.
Right now the command options don't get added to the actual command.
