### PR TITLE
Fix exception when uploading files

### DIFF
--- a/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/ChannelHelper.cs
@@ -374,7 +374,7 @@ namespace Discord.Rest
 
             if (channel is ITextChannel guildTextChannel)
             {
-                var contentSize = (ulong)attachments.Sum(x => x.Stream.Length);
+                ulong contentSize = (ulong)attachments.Where(x => x.Stream.CanSeek).Sum(x => x.Stream.Length);
 
                 if (contentSize > guildTextChannel.Guild.MaxUploadLimit)
                 {


### PR DESCRIPTION
## Summary
This PR fixes #416 by only trying to read the streams length when the `CanSeek` property is true.