### PR TITLE
Change AddReactionsAsync() and RemoveReactionsAsync() signature

### DIFF
--- a/src/Discord.Net.Core/Extensions/MessageExtensions.cs
+++ b/src/Discord.Net.Core/Extensions/MessageExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Discord
@@ -34,18 +35,19 @@ namespace Discord
         /// </code>
         /// </example>
         /// <param name="msg">The message to add reactions to.</param>
-        /// <param name="reactions">An array of reactions to add to the message.</param>
+        /// <param name="reactions">An enumerable of reactions to add to the message.</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous operation for adding a reaction to this message.
         /// </returns>
         /// <seealso cref="IMessage.AddReactionAsync(IEmote, RequestOptions)"/>
         /// <seealso cref="IEmote"/>
-        public static async Task AddReactionsAsync(this IUserMessage msg, IEmote[] reactions, RequestOptions options = null)
+        public static async Task AddReactionsAsync(this IUserMessage msg, IEnumerable<IEmote> reactions, RequestOptions options = null)
         {
             foreach (var rxn in reactions)
                 await msg.AddReactionAsync(rxn, options).ConfigureAwait(false);
         }
+
         /// <summary>
         ///     Remove multiple reactions from a message.
         /// </summary>
@@ -60,14 +62,14 @@ namespace Discord
         /// </example>
         /// <param name="msg">The message to remove reactions from.</param>
         /// <param name="user">The user who removed the reaction.</param>
-        /// <param name="reactions">An array of reactions to remove from the message.</param>
+        /// <param name="reactions">An enumerable of reactions to remove from the message.</param>
         /// <param name="options">The options to be used when sending the request.</param>
         /// <returns>
         ///     A task that represents the asynchronous operation for removing a reaction to this message.
         /// </returns>
         /// <seealso cref="IMessage.RemoveReactionAsync(IEmote, IUser, RequestOptions)"/>
         /// <seealso cref="IEmote"/>
-        public static async Task RemoveReactionsAsync(this IUserMessage msg, IUser user, IEmote[] reactions, RequestOptions options = null)
+        public static async Task RemoveReactionsAsync(this IUserMessage msg, IUser user, IEnumerable<IEmote> reactions, RequestOptions options = null)
         {
             foreach (var rxn in reactions)
                 await msg.RemoveReactionAsync(rxn, user, options).ConfigureAwait(false);


### PR DESCRIPTION
Resolves #425 

Changes reactions to be `IEnumerable<IEmote>` instead of `IEmote[]`. Makes it easier to use straight off linq operations or other enumerables without having to always call `ToArray()`