### PR TITLE
Enforce valid button styles

### DIFF
--- a/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
+++ b/src/Discord.Net.Core/Entities/Interactions/MessageComponents/ComponentBuilder.cs
@@ -608,6 +608,9 @@ namespace Discord
             if (!(string.IsNullOrEmpty(Url) ^ string.IsNullOrEmpty(CustomId)))
                 throw new InvalidOperationException("A button must contain either a URL or a CustomId, but not both!");
 
+            if (Style == 0)
+                throw new ArgumentException("A button must have a style.", nameof(Style));
+
             if (Style == ButtonStyle.Link)
             {
                 if (string.IsNullOrEmpty(Url))


### PR DESCRIPTION
This fixes throws an exception when users to not properly create a button builder. 
(see [this](https://canary.discord.com/channels/848176216011046962/848177594426851328/932358537059913748) and [this](https://canary.discord.com/channels/848176216011046962/848177362385502218/926213084538880050) in [the discord](https://discord.gg/dnet))

resolves #430 